### PR TITLE
Add Dependabot groups to consolidate ecosystem updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,16 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: pre-commit
     directory: /
     schedule:
       interval: daily
+    groups:
+      pre-commit:
+        patterns:
+          - "*"


### PR DESCRIPTION
Group all updates per ecosystem into a single PR per day rather than one PR per package. This reduces noise and makes the auto-merge workflow more effective.