### PR TITLE
Extract parseExtraArgs and add split-form flag tests

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417  # v6.3.0
         with:
-          go-version: 1.24.5
+          go-version: 1.25.8
 
       - name: Run tests and save output
         run: |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ Runs OpenTofu automated tests defined in `.tftest.hcl` files.
   - id: tofu-test
    # Optional: pass additional args to tofu test
    # args: ["-verbose"]
+   # args: ["-filter=TestFoo"]   # equals-form flag
+   # args: ["-filter", "TestFoo"] # split-form flag (both tokens required)
 ```
+
+Both equals-form (`-filter=TestFoo`) and split-form (`-filter TestFoo`) flags are supported. When using split-form flags, include both the flag and its value as separate list entries.
 
 Replace `<release-or-commit-sha>` with the desired version or commit hash.
 

--- a/cmd/tofutest/main.go
+++ b/cmd/tofutest/main.go
@@ -103,18 +103,32 @@ func printStatus(emoji, msg string) {
 	fmt.Println(output.EmojiColorText(emoji, msg, output.Green))
 }
 
-// parseExtraArgs filters os.Args tokens, keeping only flags (tokens starting with '-')
-// and their values. Equals-form flags (-flag=value) are kept as a single token.
-// Split-form flags (-flag value) are kept as two tokens.
+// parseExtraArgs filters os.Args tokens, keeping only flags (tokens starting
+// with '-') and their values. Equals-form flags (-flag=value) are kept as a
+// single token. Split-form flags (-flag value) are kept as two tokens, but
+// only for flags known to accept a value argument — boolean flags will not
+// accidentally consume the next token. A "--" token ends flag processing.
 func parseExtraArgs(args []string) []string {
+	// knownValueFlags lists tofu test flags that accept a value in split form.
+	knownValueFlags := map[string]bool{
+		"-filter":         true,
+		"-test-directory": true,
+		"-var":            true,
+		"-var-file":       true,
+	}
+
 	extraArgs := []string{}
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		if arg == "--" {
+			break
+		}
 		if strings.HasPrefix(arg, "-") {
 			extraArgs = append(extraArgs, arg)
-			// If this flag doesn't contain '=' and the next token exists and doesn't
-			// start with '-', it's a split-form flag — include the value too.
-			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			// Only consume the next token as a value for flags known to accept
+			// one, and only when no value is already embedded via '='.
+			if !strings.Contains(arg, "=") && knownValueFlags[arg] &&
+				i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				extraArgs = append(extraArgs, args[i+1])
 				i++ // skip the value token
 			}

--- a/cmd/tofutest/main.go
+++ b/cmd/tofutest/main.go
@@ -10,23 +10,8 @@ import (
 )
 
 func main() {
-	// Only pass flags (arguments starting with '-') to tofu commands
-	extraArgs := []string{}
-	args := os.Args[1:]
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if strings.HasPrefix(arg, "-") {
-			extraArgs = append(extraArgs, arg)
-			// If this flag doesn't contain '=' and next token exists and doesn't start with '-',
-			// it's a split-form flag, so include the value
-			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
-				extraArgs = append(extraArgs, args[i+1])
-				i++ // Skip the next token since we just consumed it
-			}
-		}
-	}
 	err := RunTofuTestCLI(
-		extraArgs,
+		parseExtraArgs(os.Args[1:]),
 		tofutest.CheckOpenTofuInstalled,
 		os.Getwd,
 		tofutest.HasTestFiles,
@@ -116,4 +101,24 @@ func printIndentedOutput(output string, addNewline bool) {
 // printStatus prints a colored emoji status message
 func printStatus(emoji, msg string) {
 	fmt.Println(output.EmojiColorText(emoji, msg, output.Green))
+}
+
+// parseExtraArgs filters os.Args tokens, keeping only flags (tokens starting with '-')
+// and their values. Equals-form flags (-flag=value) are kept as a single token.
+// Split-form flags (-flag value) are kept as two tokens.
+func parseExtraArgs(args []string) []string {
+	extraArgs := []string{}
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if strings.HasPrefix(arg, "-") {
+			extraArgs = append(extraArgs, arg)
+			// If this flag doesn't contain '=' and the next token exists and doesn't
+			// start with '-', it's a split-form flag — include the value too.
+			if !strings.Contains(arg, "=") && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+				extraArgs = append(extraArgs, args[i+1])
+				i++ // skip the value token
+			}
+		}
+	}
+	return extraArgs
 }

--- a/cmd/tofutest/main_test.go
+++ b/cmd/tofutest/main_test.go
@@ -186,3 +186,57 @@ func TestRunTofuTestCLI_ExtraArgs(t *testing.T) {
 		t.Errorf("Expected second arg to be -filter=TestFoo, got %s", receivedArgs[1])
 	}
 }
+
+func TestParseExtraArgs_StandardFlag(t *testing.T) {
+	got := parseExtraArgs([]string{"-verbose"})
+	if len(got) != 1 || got[0] != "-verbose" {
+		t.Errorf("parseExtraArgs([-verbose]) = %v, want [-verbose]", got)
+	}
+}
+
+func TestParseExtraArgs_EqualForm(t *testing.T) {
+	got := parseExtraArgs([]string{"-filter=TestFoo"})
+	if len(got) != 1 || got[0] != "-filter=TestFoo" {
+		t.Errorf("parseExtraArgs([-filter=TestFoo]) = %v, want [-filter=TestFoo]", got)
+	}
+}
+
+func TestParseExtraArgs_SplitForm(t *testing.T) {
+	got := parseExtraArgs([]string{"-filter", "TestFoo"})
+	if len(got) != 2 || got[0] != "-filter" || got[1] != "TestFoo" {
+		t.Errorf("parseExtraArgs([-filter TestFoo]) = %v, want [-filter TestFoo]", got)
+	}
+}
+
+func TestParseExtraArgs_Mixed(t *testing.T) {
+	got := parseExtraArgs([]string{"-verbose", "-filter", "TestFoo", "-json"})
+	want := []string{"-verbose", "-filter", "TestFoo", "-json"}
+	if len(got) != len(want) {
+		t.Fatalf("parseExtraArgs() = %v, want %v", got, want)
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("parseExtraArgs()[%d] = %q, want %q", i, got[i], v)
+		}
+	}
+}
+
+func TestParseExtraArgs_NonFlagTokensOnly(t *testing.T) {
+	got := parseExtraArgs([]string{"file1.tf", "file2.tofu"})
+	if len(got) != 0 {
+		t.Errorf("parseExtraArgs() = %v, want empty slice", got)
+	}
+}
+
+func TestParseExtraArgs_TrailingFlagNoValue(t *testing.T) {
+	got := parseExtraArgs([]string{"-verbose", "-filter"})
+	want := []string{"-verbose", "-filter"}
+	if len(got) != len(want) {
+		t.Fatalf("parseExtraArgs() = %v, want %v", got, want)
+	}
+	for i, v := range want {
+		if got[i] != v {
+			t.Errorf("parseExtraArgs()[%d] = %q, want %q", i, got[i], v)
+		}
+	}
+}

--- a/cmd/tofutest/main_test.go
+++ b/cmd/tofutest/main_test.go
@@ -240,3 +240,19 @@ func TestParseExtraArgs_TrailingFlagNoValue(t *testing.T) {
 		}
 	}
 }
+
+func TestParseExtraArgs_BoolFlagDoesNotCapturePositional(t *testing.T) {
+	// Boolean flags must not consume a following positional token.
+	got := parseExtraArgs([]string{"-verbose", "file.tf"})
+	if len(got) != 1 || got[0] != "-verbose" {
+		t.Errorf("parseExtraArgs([-verbose file.tf]) = %v, want [-verbose]", got)
+	}
+}
+
+func TestParseExtraArgs_EndOfFlags(t *testing.T) {
+	// A "--" token must end flag processing; everything after is ignored.
+	got := parseExtraArgs([]string{"-verbose", "--", "-filter", "TestFoo"})
+	if len(got) != 1 || got[0] != "-verbose" {
+		t.Errorf("parseExtraArgs([-verbose -- -filter TestFoo]) = %v, want [-verbose]", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module pre-commit-hooks
 
-go 1.25.5
+go 1.25.8


### PR DESCRIPTION
Closes #18

## What

Extracts the argument-parsing loop from `main()` into a standalone `parseExtraArgs()` function, making it independently unit-testable without spawning a subprocess.

Adds `TestParseExtraArgs_*` test cases covering:

- Standard flags (`-verbose`)
- Equals-form flags (`-filter=TestFoo`)
- Split-form flags (`-filter TestFoo` as two tokens)
- Mixed flag forms
- Non-flag-only input (pre-commit passes filenames — should yield empty)
- Trailing flag with no following value

Updates the README `tofu-test` section to document both equals-form and split-form flag usage with examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified supported -filter flag forms and that split-form flags require both flag and separate value entries.

* **Refactor**
  * Improved CLI argument parsing to better handle split-form flags, avoid unintended value consumption, and honor end-of-flags (`--`) semantics.

* **Tests**
  * Added unit tests covering boolean flags, equals-form and split-form flags, mixed sequences, trailing tokens, and `--` behavior.

* **Chore**
  * Updated CI Go toolchain version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->