### PR TITLE
Wrap runTest error to preserve failure context

### DIFF
--- a/cmd/tofutest/main.go
+++ b/cmd/tofutest/main.go
@@ -70,7 +70,7 @@ func RunTofuTestCLI(
 		printStatus(output.Error, "OpenTofu test failed.")
 		fmt.Println()
 		exit(1)
-		return fmt.Errorf("test failed")
+		return fmt.Errorf("test failed: %w", err)
 	}
 
 	printStatus(output.ThumbsUp, "OpenTofu test completed successfully.")

--- a/cmd/tofutest/main_test.go
+++ b/cmd/tofutest/main_test.go
@@ -133,21 +133,25 @@ func TestRunTofuTestCLI_TestSuccess(t *testing.T) {
 func TestRunTofuTestCLI_TestFailure(t *testing.T) {
 	called := false
 	exitCode := 0
-	
+	rootCause := errors.New("test error")
+
 	checkInstalled := func() bool { return true }
 	getwd := func() (string, error) { return "/fake", nil }
 	hasTestFiles := func(string) (bool, error) { return true, nil }
-	runTest := func(string, []string) (string, error) { return "Test failed", errors.New("test error") }
+	runTest := func(string, []string) (string, error) { return "Test failed", rootCause }
 	printStatus := func(string, string) {}
-	exit := func(code int) { 
+	exit := func(code int) {
 		exitCode = code
 		called = true
 	}
 
 	err := RunTofuTestCLI(nil, checkInstalled, getwd, hasTestFiles, runTest, printStatus, exit)
-	
+
 	if err == nil {
 		t.Error("Expected error when tests fail, got nil")
+	}
+	if !errors.Is(err, rootCause) {
+		t.Errorf("Expected returned error to wrap root cause, got: %v", err)
 	}
 	if !called {
 		t.Error("Expected exit to be called")


### PR DESCRIPTION
Closes #17

## What

`RunTofuTestCLI` was returning `fmt.Errorf("test failed")` on test failure, discarding the underlying `err` from `runTest`. Callers using `errors.Is`/`errors.As` had no way to inspect the root cause.

Changed to `fmt.Errorf("test failed: %w", err)` so the original error is preserved in the chain.

Updated `TestRunTofuTestCLI_TestFailure` to assert `errors.Is(err, rootCause)`, confirming the wrap is in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting for test failures to include underlying error context, providing more detailed diagnostic information for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->