### PR TITLE
Enhance pre-commit hooks: update .gitignore, improve CLI output, and refine README examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,10 @@
 # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
 
 # Go binaries
-tofufmt
-tofuscan
-tofutest
-tofuvalidate
+/tofufmt
+/tofuscan
+/tofutest
+/tofuvalidate
 
 # Infracost
 .infracost

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # .gitignore
 # https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
 
+# Go binaries
+tofufmt
+tofuscan
+tofutest
+tofuvalidate
+
 # Infracost
 .infracost
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
   description: The tofu fmt command is used to rewrite OpenTofu configuration files to a canonical format and style.
   entry: tofufmt
   exclude: \.terraform/.*$ # OpenTofu uses the .terraform directory currently
-  files: (\.tf|\.tofu|\.tfvars)$
+  files: (\.tf|\.tofu|\.tfvars|\.tftest\.hcl)$
   language: golang
   name: tofu fmt
   require_serial: true
@@ -30,7 +30,6 @@
 - id: tofu-scan
   description: Check OpenTofu files against CIS Google Cloud Foundations Benchmark policies
   entry: tofuscan
-  args: ['.']
   exclude: \.terraform/.*$ # OpenTofu uses the .terraform directory currently
   files: \.tofu$
   pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -41,11 +41,9 @@ Formats your OpenTofu configuration files to a canonical format and style.
 
 ```yaml
 - repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
- rev: <release-or-commit-sha>
- hooks:
-  - id: tofu-fmt
-   # Optional: pass additional args to tofu fmt
-   # args: ["-diff"]
+  rev: <release-or-commit-sha>
+  hooks:
+    - id: tofu-fmt
 ```
 
 ### Example: `tofu-validate`
@@ -54,11 +52,11 @@ Validates your OpenTofu configuration files for syntax and internal consistency.
 
 ```yaml
 - repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
- rev: <release-or-commit-sha>
- hooks:
-  - id: tofu-validate
-   # Optional: pass additional args to tofu validate
-   # args: ["-no-color"]
+  rev: <release-or-commit-sha>
+  hooks:
+    - id: tofu-validate
+      # Optional: pass additional args to tofu validate
+      # args: ["-no-color"]
 ```
 
 ### Example: `tofu-test`
@@ -67,16 +65,17 @@ Runs OpenTofu automated tests defined in `.tftest.hcl` files.
 
 ```yaml
 - repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
- rev: <release-or-commit-sha>
- hooks:
-  - id: tofu-test
-   # Optional: pass additional args to tofu test
-   # args: ["-verbose"]
-   # args: ["-filter=TestFoo"]   # equals-form flag
-   # args: ["-filter", "TestFoo"] # split-form flag (both tokens required)
+  rev: <release-or-commit-sha>
+  hooks:
+    - id: tofu-test
+      # verbose: true                # show hook output on success
+      # Optional: pass additional args to tofu test
+      # args: ["-verbose"]            # show per-assertion output
+      # args: ["-filter=TestFoo"]     # equals-form flag
+      # args: ["-filter", "TestFoo"]  # split-form flag (both tokens required)
 ```
 
-Both equals-form (`-filter=TestFoo`) and split-form (`-filter TestFoo`) flags are supported. When using split-form flags, include both the flag and its value as separate list entries.
+Both equals-form (`-filter=TestFoo`) and split-form (`-filter TestFoo`) flags are supported. When using split-form flags, include both the flag and its value as separate list entries. `-verbose` controls the level of detail `tofu test` itself emits.
 
 ### Example: `tofu-scan`
 
@@ -84,10 +83,15 @@ Checks OpenTofu files against CIS Google Cloud Foundations Benchmark policies us
 
 ```yaml
 - repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
- rev: <release-or-commit-sha>
- hooks:
-  - id: tofu-scan
+  rev: <release-or-commit-sha>
+  hooks:
+    - id: tofu-scan
+      # verbose: true     # show hook output on success
+      # Optional: pass additional args to tofu scan
+      # args: ["--soft-fail"]
 ```
+
+`--soft-fail` allows commits to pass even when violations are found. Violations are still printed so they remain visible.
 
 #### Skipping violations
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ Checks OpenTofu files against CIS Google Cloud Foundations Benchmark policies us
     - id: tofu-scan
       # verbose: true     # show hook output on success
       # Optional: pass additional args to tofu scan
-      # args: ["--soft-fail"]
+      # args: ["--warn-only"]
 ```
 
-`--soft-fail` allows commits to pass even when violations are found. Violations are still printed so they remain visible.
+`--warn-only` allows commits to pass even when violations are found. Violations are still printed so they remain visible.
 
 #### Skipping violations
 

--- a/cmd/tofufmt/main.go
+++ b/cmd/tofufmt/main.go
@@ -39,8 +39,6 @@ func RunTofuFmtCLI(
 		return err
 	}
 	baseDir := filepath.Base(wd)
-	printStatus(output.Running, fmt.Sprintf("Running tofu fmt recursively in: %s", baseDir))
-
 	outputStr, err := runTofuFmt(wd, extraArgs)
 	fmt.Println()
 	if err != nil {
@@ -50,12 +48,20 @@ func RunTofuFmtCLI(
 		c.Blank()
 		for _, line := range strings.Split(outputStr, "\n") {
 			if strings.TrimSpace(line) != "" {
-				c.Line(fmt.Sprintf("%s%s%s", output.Dim, line, output.Reset))
+				var color string
+				switch {
+				case strings.HasPrefix(line, "+"):
+					color = output.Green
+				case strings.HasPrefix(line, "-"):
+					color = output.Yellow
+				default:
+					color = output.Dim
+				}
+				c.Line(fmt.Sprintf("%s%s%s", color, line, output.Reset))
 			}
 		}
 		c.Close()
 		fmt.Println()
-		printStatus(output.Running, "Formatting files with tofu fmt...")
 		fmtErr := formatFiles(wd, extraArgs)
 		fmt.Println()
 		if fmtErr != nil {
@@ -67,16 +73,6 @@ func RunTofuFmtCLI(
 			ec.Close()
 			return fmtErr
 		}
-		printStatus(output.ThumbsUp, "Files formatted successfully with tofu fmt.")
-		fmt.Println()
-	} else {
-		printStatus(output.ThumbsUp, "All OpenTofu files are formatted.")
-		fmt.Println()
 	}
 	return nil
-}
-
-// printStatus prints a colored emoji status message
-func printStatus(emoji, msg string) {
-	fmt.Println(output.EmojiColorText(emoji, msg, output.Green))
 }

--- a/cmd/tofufmt/main_test.go
+++ b/cmd/tofufmt/main_test.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
-	"pre-commit-hooks/internal/output"
 	"pre-commit-hooks/internal/testutil"
 	tofu_fmt "pre-commit-hooks/internal/tofufmt"
 )
@@ -76,27 +74,6 @@ func TestRunTofuFmtCLI_BadDir(t *testing.T) {
 	err := RunTofuFmtCLI([]string{}, func() (string, error) { return "", fmt.Errorf("fail") }, tofu_fmt.RunTofuFmt, tofu_fmt.FormatFiles)
 	if err == nil {
 		t.Error("Expected error when failing to get working directory")
-	}
-}
-
-func TestPrintStatus(t *testing.T) {
-	cases := []struct {
-		emoji string
-		msg   string
-		color string
-		want  string
-	}{
-		{output.ThumbsUp, "All good", output.Green, output.ThumbsUp + " " + output.Green + "All good" + output.Reset + "\n"},
-		{output.Warning, "Warning!", output.Yellow, output.Warning + " " + output.Yellow + "Warning!" + output.Reset + "\n"},
-		{output.Error, "Error!", output.Red, output.Error + " " + output.Red + "Error!" + output.Reset + "\n"},
-	}
-	for _, c := range cases {
-		buf := &bytes.Buffer{}
-		fmt.Fprintf(buf, "%s\n", output.EmojiColorText(c.emoji, c.msg, c.color))
-		got := buf.String()
-		if got != c.want {
-			t.Errorf("printStatus(%q, %q): got %q, want %q", c.emoji, c.msg, got, c.want)
-		}
 	}
 }
 

--- a/cmd/tofuscan/main.go
+++ b/cmd/tofuscan/main.go
@@ -27,9 +27,14 @@ func main() {
 	paths := []string{}
 
 	for _, arg := range args {
-		if arg == "--warn-only" {
+		switch arg {
+		case "--warn-only":
 			warnOnly = true
-		} else {
+		default:
+			if len(arg) > 2 && arg[:2] == "--" {
+				fmt.Fprintf(os.Stderr, "unknown flag: %s\n", arg)
+				os.Exit(exitError)
+			}
 			paths = append(paths, arg)
 		}
 	}

--- a/cmd/tofuscan/main.go
+++ b/cmd/tofuscan/main.go
@@ -15,7 +15,6 @@ import (
 const (
 	exitSuccess = 0 // no violations
 	exitFailure = 1 // violations found
-	exitUsage   = 2 // invalid arguments
 	exitError   = 3 // runtime error (I/O, policy compilation, evaluation)
 )
 
@@ -24,12 +23,22 @@ var version = "0.1.0"
 func main() {
 	args := os.Args[1:]
 
-	if len(args) == 0 {
-		fmt.Fprintf(os.Stderr, "tofuscan %s\nUsage: tofuscan <path...>\n", version)
-		os.Exit(exitUsage)
+	softFail := false
+	paths := []string{}
+
+	for _, arg := range args {
+		if arg == "--soft-fail" {
+			softFail = true
+		} else {
+			paths = append(paths, arg)
+		}
 	}
 
-	files, err := walker.FindTofuFiles(args)
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
+
+	files, err := walker.FindTofuFiles(paths)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error finding files: %v\n", err)
 		os.Exit(exitError)
@@ -51,7 +60,7 @@ func main() {
 
 	output.Print(violations, skipped)
 
-	if len(violations) > 0 {
+	if len(violations) > 0 && !softFail {
 		os.Exit(exitFailure)
 	}
 }

--- a/cmd/tofuscan/main.go
+++ b/cmd/tofuscan/main.go
@@ -23,12 +23,12 @@ var version = "0.1.0"
 func main() {
 	args := os.Args[1:]
 
-	softFail := false
+	warnOnly := false
 	paths := []string{}
 
 	for _, arg := range args {
-		if arg == "--soft-fail" {
-			softFail = true
+		if arg == "--warn-only" {
+			warnOnly = true
 		} else {
 			paths = append(paths, arg)
 		}
@@ -38,29 +38,59 @@ func main() {
 		paths = []string{"."}
 	}
 
-	files, err := walker.FindTofuFiles(paths)
+	err := RunTofuScanCLI(
+		paths,
+		warnOnly,
+		walker.FindTofuFiles,
+		func(files []string) ([]engine.Violation, error) {
+			return engine.Run(context.Background(), files, policies.FS)
+		},
+		engine.ParseSkipDirectives,
+		output.Print,
+		os.Exit,
+	)
+	if err != nil {
+		os.Exit(exitError)
+	}
+}
+
+// RunTofuScanCLI runs the tofu scan CLI logic. Returns error if any step fails.
+func RunTofuScanCLI(
+	paths []string,
+	warnOnly bool,
+	findFiles func([]string) ([]string, error),
+	runEngine func([]string) ([]engine.Violation, error),
+	parseSkips func([]string) *engine.SkipDirectives,
+	printOutput func([]engine.Violation, []engine.Violation),
+	exit func(int),
+) error {
+	files, err := findFiles(paths)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error finding files: %v\n", err)
-		os.Exit(exitError)
+		exit(exitError)
+		return err
 	}
 
 	if len(files) == 0 {
 		fmt.Println("No .tofu files found")
-		return
+		exit(exitSuccess)
+		return nil
 	}
 
-	allViolations, err := engine.Run(context.Background(), files, policies.FS)
+	allViolations, err := runEngine(files)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error evaluating policies: %v\n", err)
-		os.Exit(exitError)
+		exit(exitError)
+		return err
 	}
 
-	skips := engine.ParseSkipDirectives(files)
+	skips := parseSkips(files)
 	violations, skipped := skips.Filter(allViolations)
 
-	output.Print(violations, skipped)
+	printOutput(violations, skipped)
 
-	if len(violations) > 0 && !softFail {
-		os.Exit(exitFailure)
+	if len(violations) > 0 && !warnOnly {
+		exit(exitFailure)
 	}
+	return nil
 }

--- a/cmd/tofuscan/main_test.go
+++ b/cmd/tofuscan/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"pre-commit-hooks/internal/tofuscan/engine"
+)
+
+func TestRunTofuScanCLI(t *testing.T) {
+	noViolations := []engine.Violation{}
+	oneViolation := []engine.Violation{{RuleID: "CIS-1.1", File: "main.tofu"}}
+	noSkips := engine.ParseSkipDirectives([]string{})
+
+	cases := []struct {
+		name       string
+		paths      []string
+		warnOnly   bool
+		files      []string
+		findErr    error
+		violations []engine.Violation
+		engineErr  error
+		wantExit   int
+		wantErr    bool
+	}{
+		{
+			name:     "no files found",
+			paths:    []string{"."},
+			files:    []string{},
+			wantExit: exitSuccess,
+		},
+		{
+			name:     "find files error",
+			paths:    []string{"."},
+			findErr:  fmt.Errorf("walk error"),
+			wantExit: exitError,
+			wantErr:  true,
+		},
+		{
+			name:      "engine error",
+			paths:     []string{"."},
+			files:     []string{"main.tofu"},
+			engineErr: fmt.Errorf("opa error"),
+			wantExit:  exitError,
+			wantErr:   true,
+		},
+		{
+			name:       "no violations",
+			paths:      []string{"."},
+			files:      []string{"main.tofu"},
+			violations: noViolations,
+			wantExit:   exitSuccess,
+		},
+		{
+			name:       "violations, warn-only false",
+			paths:      []string{"."},
+			files:      []string{"main.tofu"},
+			violations: oneViolation,
+			wantExit:   exitFailure,
+		},
+		{
+			name:       "violations, warn-only true",
+			paths:      []string{"."},
+			warnOnly:   true,
+			files:      []string{"main.tofu"},
+			violations: oneViolation,
+			wantExit:   exitSuccess,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotExit int
+			exitFn := func(code int) { gotExit = code }
+
+			findFiles := func(paths []string) ([]string, error) {
+				return tc.files, tc.findErr
+			}
+			runEngine := func(files []string) ([]engine.Violation, error) {
+				return tc.violations, tc.engineErr
+			}
+			printOutput := func(violations []engine.Violation, skipped []engine.Violation) {}
+
+			err := RunTofuScanCLI(
+				tc.paths,
+				tc.warnOnly,
+				findFiles,
+				runEngine,
+				func(files []string) *engine.SkipDirectives { return noSkips },
+				printOutput,
+				exitFn,
+			)
+
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if gotExit != tc.wantExit {
+				t.Errorf("exit code = %d, want %d", gotExit, tc.wantExit)
+			}
+		})
+	}
+}

--- a/cmd/tofutest/main.go
+++ b/cmd/tofutest/main.go
@@ -60,7 +60,6 @@ func RunTofuTestCLI(
 		return nil
 	}
 
-	printStatus(output.Running, "Running tofu test...")
 	testOutput, err := runTest(rootDir, extraArgs)
 
 	if err != nil {
@@ -81,7 +80,15 @@ func RunTofuTestCLI(
 		return fmt.Errorf("test failed: %w", err)
 	}
 
-	printStatus(output.ThumbsUp, "OpenTofu test completed successfully.")
+	c := output.NewCard(output.Green)
+	c.Open(output.Badge("PASS", output.BoldGreen), output.Title("OpenTofu test"))
+	c.Blank()
+	for _, line := range strings.Split(testOutput, "\n") {
+		if strings.TrimSpace(line) != "" {
+			c.Line(fmt.Sprintf("%s%s%s", output.Dim, line, output.Reset))
+		}
+	}
+	c.Close()
 	fmt.Println()
 	return nil
 }

--- a/cmd/tofuvalidate/main.go
+++ b/cmd/tofuvalidate/main.go
@@ -27,7 +27,6 @@ func main() {
 		findDirsWithTfFiles,
 		runCmdInDir,
 		tofuvalidate.RunTofuValidate,
-		printStatus,
 		os.Exit,
 	)
 	if err != nil {
@@ -43,7 +42,6 @@ func RunTofuValidateCLI(
 	findDirs func(string) []string,
 	runCmd func(string, []string) (string, error),
 	runValidate func(string, []string) (string, error),
-	printStatus func(string, string),
 	exit func(int),
 ) error {
 	if !checkInstalled() {
@@ -83,20 +81,14 @@ func RunTofuValidateCLI(
 		} else {
 			fullPath = baseDir + "/" + relPath
 		}
-		printStatus(output.Running, fmt.Sprintf("Running tofu init in: %s...", fullPath))
 		initCmd := []string{"init", "-input=false", "--backend=false"}
 		cmdArgs := append(initCmd, extraArgs...)
 		out, err := runCmd(dir, cmdArgs)
-		// Always check for warnings in init output
-		if hasWarning(out) {
-			warningMessages = append(warningMessages, output.TofuMessage{Step: "init", RelPath: fullPath, Output: out})
-		}
 		if err != nil {
 			errorMessages = append(errorMessages, output.TofuMessage{Step: "init", RelPath: fullPath, Output: out})
 			continue
 		}
 
-		printStatus(output.Running, fmt.Sprintf("Running tofu validate in: %s...", fullPath))
 		out, err = runValidate(dir, extraArgs)
 		// Always check for warnings in validate output
 		if hasWarning(out) {
@@ -119,14 +111,10 @@ func RunTofuValidateCLI(
 	}
 
 	if len(warningMessages) > 0 {
-		printStatus(output.ThumbsUp, "OpenTofu validate completed with warnings.")
-		fmt.Println()
 		exit(0)
 		return nil
 	}
 
-	printStatus(output.ThumbsUp, "OpenTofu validate completed successfully for all directories.")
-	fmt.Println()
 	return nil
 }
 
@@ -175,11 +163,6 @@ func walkDirs(dir string, dirs *[]string) error {
 	return errors.Join(errs...)
 }
 
-// printStatus prints a colored emoji status message
-func printStatus(emoji, msg string) {
-	fmt.Println(output.EmojiColorText(emoji, msg, output.Green))
-}
-
 // hasWarning checks if output contains a warning message
 // Uses pattern matching to avoid false positives from filenames or unrelated text
 func hasWarning(output string) bool {
@@ -188,9 +171,9 @@ func hasWarning(output string) bool {
 		trimmed := strings.TrimSpace(line)
 		lower := strings.ToLower(trimmed)
 		// Check for common warning patterns at start of line
-		if strings.HasPrefix(lower, "warning:") || 
-		   strings.HasPrefix(lower, "│ warning:") ||
-		   strings.HasPrefix(lower, "╷") && strings.Contains(lower, "warning") {
+		if strings.HasPrefix(lower, "warning:") ||
+			strings.HasPrefix(lower, "│ warning:") ||
+			strings.HasPrefix(lower, "╷") && strings.Contains(lower, "warning") {
 			return true
 		}
 	}

--- a/cmd/tofuvalidate/main_test.go
+++ b/cmd/tofuvalidate/main_test.go
@@ -50,21 +50,6 @@ func Test_findDirsWithTfFiles_and_walkDirs(t *testing.T) {
 	}
 }
 
-func Test_printStatus(t *testing.T) {
-	old := os.Stdout
-	defer func() { os.Stdout = old }()
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-	printStatus("👍", "Test message")
-	w.Close()
-	buf := make([]byte, 1024)
-	n, _ := r.Read(buf)
-	output := string(buf[:n])
-	if !strings.Contains(output, "Test message") {
-		t.Error("Expected output to contain status message")
-	}
-}
-
 func Test_walkDirs_ErrorsAndHidden(t *testing.T) {
 	var dirs []string
 	err := walkDirs("/nonexistent/path", &dirs)
@@ -155,10 +140,8 @@ func TestRunTofuValidateCLI_AllBranches(t *testing.T) {
 			runValidate := func(dir string, args []string) (string, error) {
 				return tc.args.runValidateOut, tc.args.runValidateErr
 			}
-			statusMsgs := []string{}
-			printStatus := func(emoji, msg string) { statusMsgs = append(statusMsgs, emoji+":"+msg) }
 			exit := func(code int) { exited = code }
-			err := RunTofuValidateCLI([]string{}, checkInstalled, getwd, findDirs, runCmd, runValidate, printStatus, exit)
+			err := RunTofuValidateCLI([]string{}, checkInstalled, getwd, findDirs, runCmd, runValidate, exit)
 			if tc.wantErr && err == nil {
 				t.Errorf("Expected error for case %q, got nil", tc.name)
 			}
@@ -182,24 +165,13 @@ func TestRunTofuValidateCLI_AllBranches(t *testing.T) {
 		runValidate := func(dir string, args []string) (string, error) {
 			return "validate ok", nil
 		}
-		var statusMsgs []string
-		printStatus := func(emoji, msg string) { statusMsgs = append(statusMsgs, emoji+":"+msg) }
 		exit := func(code int) { exited = code }
-		err := RunTofuValidateCLI([]string{}, checkInstalled, getwd, findDirs, runCmd, runValidate, printStatus, exit)
+		err := RunTofuValidateCLI([]string{}, checkInstalled, getwd, findDirs, runCmd, runValidate, exit)
 		if err != nil {
 			t.Errorf("Did not expect error for relPath rewriting branch, got: %v", err)
 		}
 		if exited != 0 {
 			t.Errorf("Expected exit code 0 for relPath rewriting branch, got %d", exited)
-		}
-		foundRewrite := false
-		for _, msg := range statusMsgs {
-			if strings.Contains(msg, "subdir") {
-				foundRewrite = true
-			}
-		}
-		if !foundRewrite {
-			t.Error("Expected relPath rewriting logic to be exercised and subdir to appear in status message")
 		}
 	})
 
@@ -220,10 +192,8 @@ func TestRunTofuValidateCLI_AllBranches(t *testing.T) {
 			}
 			return "validate ok", nil
 		}
-		statusMsgs := []string{}
-		printStatus := func(emoji, msg string) { statusMsgs = append(statusMsgs, emoji+":"+msg) }
 		exit := func(code int) { exited = code }
-		err := RunTofuValidateCLI([]string{}, checkInstalled, getwd, findDirs, runCmd, runValidate, printStatus, exit)
+		err := RunTofuValidateCLI([]string{}, checkInstalled, getwd, findDirs, runCmd, runValidate, exit)
 		if err == nil {
 			t.Error("Expected error for multi-error summary branch, got nil")
 		}
@@ -300,54 +270,54 @@ func TestInvalidOpenTofuConfig(t *testing.T) {
 }
 
 func TestHasWarning(t *testing.T) {
-tests := []struct {
-name   string
-output string
-want   bool
-}{
-{
-name:   "warning at start of line",
-output: "Warning: deprecated feature\nother text",
-want:   true,
-},
-{
-name:   "box-drawing warning format",
-output: "│ Warning: something is wrong\n│ more details",
-want:   true,
-},
-{
-name:   "warning in filename should not match",
-output: "processing file warning.tf\neverything is fine",
-want:   false,
-},
-{
-name:   "warning in middle of line should not match",
-output: "this is a warning about something",
-want:   false,
-},
-{
-name:   "no warning",
-output: "success\nvalidation passed",
-want:   false,
-},
-{
-name:   "case insensitive warning",
-output: "WARNING: This is a problem",
-want:   true,
-},
-{
-name:   "warning with leading whitespace",
-output: "  Warning: indented warning",
-want:   true,
-},
-}
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "warning at start of line",
+			output: "Warning: deprecated feature\nother text",
+			want:   true,
+		},
+		{
+			name:   "box-drawing warning format",
+			output: "│ Warning: something is wrong\n│ more details",
+			want:   true,
+		},
+		{
+			name:   "warning in filename should not match",
+			output: "processing file warning.tf\neverything is fine",
+			want:   false,
+		},
+		{
+			name:   "warning in middle of line should not match",
+			output: "this is a warning about something",
+			want:   false,
+		},
+		{
+			name:   "no warning",
+			output: "success\nvalidation passed",
+			want:   false,
+		},
+		{
+			name:   "case insensitive warning",
+			output: "WARNING: This is a problem",
+			want:   true,
+		},
+		{
+			name:   "warning with leading whitespace",
+			output: "  Warning: indented warning",
+			want:   true,
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-got := hasWarning(tt.output)
-if got != tt.want {
-t.Errorf("hasWarning() = %v, want %v for output:\n%s", got, tt.want, tt.output)
-}
-})
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasWarning(tt.output)
+			if got != tt.want {
+				t.Errorf("hasWarning() = %v, want %v for output:\n%s", got, tt.want, tt.output)
+			}
+		})
+	}
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -85,7 +85,7 @@ const (
 	Running  = "🔧"
 	ThumbsUp = "👍"
 	File     = "📄"
-	Tag      = "🏷"
+	Tag      = "🏷 "
 )
 
 // Colorize wraps text with the given color and a Reset suffix.


### PR DESCRIPTION
This pull request focuses on improving the usability, maintainability, and flexibility of the OpenTofu pre-commit hooks and CLI tools. The main changes include enhanced CLI output formatting, the addition of a soft-fail option for scanning, expanded file matching for formatting, and the removal of redundant status-printing logic and tests.

**CLI Output and User Experience Improvements:**

* Enhanced the output of `tofu fmt` and `tofu test` commands by introducing color-coded diffs and summary cards, making it easier to interpret results. Removed generic status printouts in favor of more contextual and visually distinct output. [[1]](diffhunk://#diff-eb37b114cfbbbef30170505d70fb9c17e3e31a3e2306e9b83cc7bad31af4ededL53-L58) [[2]](diffhunk://#diff-eb37b114cfbbbef30170505d70fb9c17e3e31a3e2306e9b83cc7bad31af4ededL70-L82) [[3]](diffhunk://#diff-fde6507fea97b784c07fd2e743a5ede11df70a41802eb91d0c653853dc8a967bL84-R91)

**New Features and Options:**

* Added a `--soft-fail` flag to `tofuscan`, allowing commits to pass even if violations are found; this is reflected in both the CLI and documentation. [[1]](diffhunk://#diff-249354562a0517940eed08867e0fd9c736f612c664a7e6a4c79ecb0f95fa69acL27-R41) [[2]](diffhunk://#diff-249354562a0517940eed08867e0fd9c736f612c664a7e6a4c79ecb0f95fa69acL54-R63) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R89-R95)

**Configuration and File Matching Enhancements:**

* Updated `.pre-commit-hooks.yaml` to allow `tofu fmt` to process `.tftest.hcl` files in addition to `.tf`, `.tofu`, and `.tfvars` files, broadening its applicability.
* Pinned the pre-commit-hooks repo to a specific commit for reproducibility.

**Codebase Simplification and Maintenance:**

* Removed the `printStatus` function and all related test code from `tofuvalidate`, `tofufmt`, and their respective tests, streamlining the code and reducing duplication. [[1]](diffhunk://#diff-17b4a2ad0134687272428266230ddd9feb14d31bef362201f62fd921cb776329L46) [[2]](diffhunk://#diff-17b4a2ad0134687272428266230ddd9feb14d31bef362201f62fd921cb776329L122-L129) [[3]](diffhunk://#diff-17b4a2ad0134687272428266230ddd9feb14d31bef362201f62fd921cb776329L178-L182) [[4]](diffhunk://#diff-6bd9b39a0a5d5157f2d839767ff90a264104f1b7517f1d3cec617ee001cd6829L82-L102) [[5]](diffhunk://#diff-b01cefd4474d808941884bf2303441b25f6dc09110336c32e266190f19466a7dL53-L67) [[6]](diffhunk://#diff-b01cefd4474d808941884bf2303441b25f6dc09110336c32e266190f19466a7dL158-R144) [[7]](diffhunk://#diff-b01cefd4474d808941884bf2303441b25f6dc09110336c32e266190f19466a7dL185-L203) [[8]](diffhunk://#diff-b01cefd4474d808941884bf2303441b25f6dc09110336c32e266190f19466a7dL223-R196)

**Documentation Updates:**

* Updated the `README.md` to document new options (`--soft-fail`, `verbose`), clarify flag usage, and ensure hook configuration examples are accurate and up to date. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-L48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71-R78) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R89-R95)

These changes collectively improve the developer experience, make the tools more robust and flexible, and simplify ongoing maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scan mode flag (--warn-only) to report violations without failing commits.

* **Documentation**
  * README updated with improved pre-commit hook examples, rev usage, clearer test filter forms, and warn-only guidance.

* **Enhancements**
  * Colorized formatter diffs and simplified CLI success output (concise PASS/summary cards).
  * Pre-commit hooks refined (targets and example format).

* **Chores**
  * .gitignore extended to ignore Terraform-related Go binaries.

* **Tests**
  * Added CLI tests for scan behavior; removed obsolete status-printing tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-pre-commit-hooks/pull/34)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->