### PR TITLE
Scale fmt diff output to terminal width

### DIFF
--- a/cmd/tofufmt/main.go
+++ b/cmd/tofufmt/main.go
@@ -10,6 +10,16 @@ import (
 	"pre-commit-hooks/internal/tofufmt"
 )
 
+// truncateLine truncates s to maxWidth runes, appending "…" if truncated.
+// Lines at or below maxWidth (or when maxWidth <= 1) are returned unchanged.
+func truncateLine(s string, maxWidth int) string {
+	runes := []rune(s)
+	if maxWidth <= 1 || len(runes) <= maxWidth {
+		return s
+	}
+	return string(runes[:maxWidth-1]) + "…"
+}
+
 func main() {
 	err := RunTofuFmtCLI(
 		os.Args[1:],
@@ -48,6 +58,8 @@ func RunTofuFmtCLI(
 		c.Open(output.Badge("WARNING", output.BoldYellow), output.Title("Unformatted OpenTofu files"))
 		c.Line(fmt.Sprintf("%s %s", output.File, output.Colorize(baseDir, output.Gray)))
 		c.Blank()
+		// "│  " prefix is 3 visible chars; subtract to get usable content width.
+		contentWidth := output.TermWidth() - 3
 		for _, line := range strings.Split(outputStr, "\n") {
 			if strings.TrimSpace(line) != "" {
 				var color string
@@ -59,7 +71,7 @@ func RunTofuFmtCLI(
 				default:
 					color = output.Dim
 				}
-				c.Line(fmt.Sprintf("%s%s%s", color, line, output.Reset))
+				c.Line(fmt.Sprintf("%s%s%s", color, truncateLine(line, contentWidth), output.Reset))
 			}
 		}
 		c.Close()

--- a/cmd/tofufmt/main_test.go
+++ b/cmd/tofufmt/main_test.go
@@ -10,6 +10,30 @@ import (
 	"pre-commit-hooks/internal/testutil"
 )
 
+func TestTruncateLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		line  string
+		width int
+		want  string
+	}{
+		{"short line unchanged", "hello", 20, "hello"},
+		{"exact width unchanged", "hello", 5, "hello"},
+		{"truncated with ellipsis", "hello world", 8, "hello w…"},
+		{"zero width unchanged", "hello", 0, "hello"},
+		{"width 1 unchanged", "hello", 1, "hello"},
+		{"multibyte chars", "héllo wörld", 8, "héllo w…"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateLine(tc.line, tc.width)
+			if got != tc.want {
+				t.Errorf("truncateLine(%q, %d) = %q, want %q", tc.line, tc.width, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRunTofuFmtCLI_AllBranches(t *testing.T) {
 	type mockArgs struct {
 		checkInstalled bool

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -99,10 +99,19 @@ func EmojiColorText(emoji, text, color string) string {
 }
 
 // TermWidth returns the terminal width, defaulting to 80 if detection fails.
+// It tries stdout, then stderr, then /dev/tty — because pre-commit pipes
+// stdout, making it a non-TTY fd, so we need a fallback to the controlling terminal.
 func TermWidth() int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
-	if err != nil || w <= 0 {
-		return 80
+	for _, fd := range []int{int(os.Stdout.Fd()), int(os.Stderr.Fd())} {
+		if w, _, err := term.GetSize(fd); err == nil && w > 0 {
+			return w
+		}
 	}
-	return w
+	if tty, err := os.Open("/dev/tty"); err == nil {
+		defer tty.Close()
+		if w, _, err := term.GetSize(int(tty.Fd())); err == nil && w > 0 {
+			return w
+		}
+	}
+	return 80
 }


### PR DESCRIPTION
Truncates `tofu fmt` diff lines to fit the terminal width so long lines (e.g. module source URLs) don't overflow the card border.

**Changes:**
- Add `truncateLine` helper in `cmd/tofufmt/main.go` — rune-aware truncation with `…` suffix
- Use `TermWidth() - 3` (subtracting the `│  ` card border) as the content width when printing diff lines
- Fix `TermWidth()` to probe `stdout` → `stderr` → `/dev/tty` so width is detected correctly when pre-commit pipes stdout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI output lines now truncate to terminal width with ellipsis appended when needed.

* **Improvements**
  * Enhanced terminal width detection for piped and redirected output scenarios.

* **Tests**
  * Added unit tests for line truncation functionality across various width cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-pre-commit-hooks/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->