### PR TITLE
Rename regofu Rego package to tofuscan and extract Cloud SQL db helpers

### DIFF
--- a/internal/tofuscan/engine/engine.go
+++ b/internal/tofuscan/engine/engine.go
@@ -67,7 +67,7 @@ func Run(ctx context.Context, files []string, policiesFS fs.FS) (*RunResult, err
 	}
 
 	prepared, err := rego.New(
-		rego.Query("data.regofu.deny"),
+		rego.Query("data.tofuscan.deny"),
 		rego.Compiler(compiler),
 	).PrepareForEval(ctx)
 	if err != nil {

--- a/internal/tofuscan/policies/gcp/bigquery/7.1.rego
+++ b/internal/tofuscan/policies/gcp/bigquery/7.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/bigquery/7.2.rego
+++ b/internal/tofuscan/policies/gcp/bigquery/7.2.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/bigquery/7.3.rego
+++ b/internal/tofuscan/policies/gcp/bigquery/7.3.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.1.2.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.1.2.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_1_2 := concat("", [
 	"Setting skip_show_database=on prevents non-privileged users from using SHOW DATABASES ",
@@ -11,7 +12,7 @@ _desc_6_1_2 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "MYSQL_")
+	lib.is_mysql(resource)
 	not _has_sql_flag(resource, "skip_show_database", "on")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.1.3.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.1.3.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_1_3 := concat("", [
 	"The local_infile flag enables loading data directly from client-side files into the ",
@@ -11,7 +12,7 @@ _desc_6_1_3 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "MYSQL_")
+	lib.is_mysql(resource)
 	not _has_sql_flag(resource, "local_infile", "off")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.1.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.1.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 # VERBOSE is less strict than DEFAULT; DEFAULT and TERSE are acceptable.
 _verbose_values_6_2_1 := {"VERBOSE", "verbose"}
@@ -14,7 +15,7 @@ _desc_6_2_1 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+	lib.is_postgres(resource)
 	some settings in resource.settings
 	some flag in object.get(settings, "database_flags", [])
 	flag.name == "log_error_verbosity"

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.2.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.2.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_2_2 := concat("", [
 	"Enabling log_connections causes PostgreSQL to log each successful client connection. ",
@@ -11,7 +12,7 @@ _desc_6_2_2 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+	lib.is_postgres(resource)
 	not _has_pg_flag_on(resource, "log_connections")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.3.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.3.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_2_3 := concat("", [
 	"Enabling log_disconnections causes PostgreSQL to log session termination details. ",
@@ -11,7 +12,7 @@ _desc_6_2_3 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+	lib.is_postgres(resource)
 	not _has_pg_flag_on(resource, "log_disconnections")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.4.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.4.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 # ddl and all are acceptable; none, mod, and absent are insufficient.
 _acceptable_log_statement := {"ddl", "all"}
@@ -14,7 +15,7 @@ _desc_6_2_4 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+	lib.is_postgres(resource)
 	not _has_acceptable_log_statement(resource)
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.5.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.5.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 # Severity levels less strict than WARNING (more verbose / noisier).
 _too_verbose_6_2_5 := {
@@ -19,7 +20,7 @@ _desc_6_2_5 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+	lib.is_postgres(resource)
 	some settings in resource.settings
 	some flag in object.get(settings, "database_flags", [])
 	flag.name == "log_min_messages"

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.6.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.6.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 # Severity levels less strict than ERROR.
 _too_verbose_6_2_6 := {
@@ -20,7 +21,7 @@ _desc_6_2_6 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+	lib.is_postgres(resource)
 	some settings in resource.settings
 	some flag in object.get(settings, "database_flags", [])
 	flag.name == "log_min_error_statement"

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.7.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.7.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_2_7 := concat("", [
 	"Setting log_min_duration_statement=-1 disables logging of statement durations. ",
@@ -12,7 +13,7 @@ _desc_6_2_7 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+	lib.is_postgres(resource)
 	some settings in resource.settings
 	some flag in object.get(settings, "database_flags", [])
 	flag.name == "log_min_duration_statement"

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.8.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.8.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_2_8 := concat("", [
 	"The pgaudit extension provides detailed session and object audit logging for ",
@@ -12,7 +13,7 @@ _desc_6_2_8 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+	lib.is_postgres(resource)
 	not _has_pg_flag_on(resource, "cloudsql.enable_pgaudit")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.1.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.1.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_3_1 := concat("", [
 	"Disabling external scripts prevents execution of scripts in external languages such ",
@@ -11,7 +12,7 @@ _desc_6_3_1 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "SQLSERVER_")
+	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "external scripts enabled", "off")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.2.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.2.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_3_2 := concat("", [
 	"Cross-database ownership chaining allows users to access objects in other databases ",
@@ -11,7 +12,7 @@ _desc_6_3_2 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "SQLSERVER_")
+	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "cross db ownership chaining", "off")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.5.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.5.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_3_5 := concat("", [
 	"The remote access flag controls whether the SQL Server instance can execute stored ",
@@ -11,7 +12,7 @@ _desc_6_3_5 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "SQLSERVER_")
+	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "remote access", "off")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.6.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.6.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_3_6 := concat("", [
 	"Trace flag 3625 masks the details of SQL Server error messages shown to non-admin ",
@@ -11,7 +12,7 @@ _desc_6_3_6 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "SQLSERVER_")
+	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "3625", "on")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.7.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.7.rego
@@ -1,6 +1,7 @@
-package regofu
+package tofuscan
 
 import rego.v1
+import data.tofuscan.lib
 
 _desc_6_3_7 := concat("", [
 	"Contained databases authenticate users without requiring domain-level credentials, ",
@@ -11,7 +12,7 @@ _desc_6_3_7 := concat("", [
 deny contains violation if {
 	some name, resources in input.resource.google_sql_database_instance
 	some resource in resources
-	startswith(object.get(resource, "database_version", ""), "SQLSERVER_")
+	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "contained database authentication", "off")
 	violation := {
 		"resource": name,

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.4.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.4.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.5.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.5.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.6.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.6.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.7.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.7.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/iam/1.10.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.10.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/iam/1.5.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.5.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/iam/1.6.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.6.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/iam/1.7.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.7.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/iam/1.9.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.9.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/logging/2.2.rego
+++ b/internal/tofuscan/policies/gcp/logging/2.2.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/networking/3.1.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/networking/3.3.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.3.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/networking/3.4.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.4.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/networking/3.6.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.6.rego
@@ -1,8 +1,8 @@
-package regofu
+package tofuscan
 
 import rego.v1
 
-import data.regofu.lib
+import data.tofuscan.lib
 
 _desc_3_6 := concat("", [
 	"Firewall rules must not allow unrestricted inbound SSH (port 22) from ",

--- a/internal/tofuscan/policies/gcp/networking/3.7.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.7.rego
@@ -1,8 +1,8 @@
-package regofu
+package tofuscan
 
 import rego.v1
 
-import data.regofu.lib
+import data.tofuscan.lib
 
 _desc_3_7 := concat("", [
 	"Firewall rules must not allow unrestricted inbound RDP (port 3389) from ",

--- a/internal/tofuscan/policies/gcp/networking/3.8.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.8.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/networking/3.9.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.9.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/storage/5.1.rego
+++ b/internal/tofuscan/policies/gcp/storage/5.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/storage/5.2.rego
+++ b/internal/tofuscan/policies/gcp/storage/5.2.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.1.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.11.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.11.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.2.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.2.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.3.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.3.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.4.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.4.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.5.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.5.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.6.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.6.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.7.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.7.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.8.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.8.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.9.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.9.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/auth/5.8.1.rego
+++ b/internal/tofuscan/policies/gke/auth/5.8.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/auth/5.8.3.rego
+++ b/internal/tofuscan/policies/gke/auth/5.8.3.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/iam/5.2.1.rego
+++ b/internal/tofuscan/policies/gke/iam/5.2.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/kms/5.3.1.rego
+++ b/internal/tofuscan/policies/gke/kms/5.3.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/logging/5.7.1.rego
+++ b/internal/tofuscan/policies/gke/logging/5.7.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/networking/5.6.1.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/networking/5.6.2.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.2.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/networking/5.6.3.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.3.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/networking/5.6.4.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.4.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/networking/5.6.5.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.5.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.1.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.2.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.2.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.3.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.3.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.4.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.4.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.5.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.5.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.6.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.6.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.7.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.7.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/node_metadata/5.4.1.rego
+++ b/internal/tofuscan/policies/gke/node_metadata/5.4.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/other/5.10.1.rego
+++ b/internal/tofuscan/policies/gke/other/5.10.1.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/other/5.10.2.rego
+++ b/internal/tofuscan/policies/gke/other/5.10.2.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/gke/other/5.10.4.rego
+++ b/internal/tofuscan/policies/gke/other/5.10.4.rego
@@ -1,4 +1,4 @@
-package regofu
+package tofuscan
 
 import rego.v1
 

--- a/internal/tofuscan/policies/lib/helpers.rego
+++ b/internal/tofuscan/policies/lib/helpers.rego
@@ -1,4 +1,4 @@
-package regofu.lib
+package tofuscan.lib
 
 import rego.v1
 
@@ -8,3 +8,11 @@ import rego.v1
 is_public_cidr("0.0.0.0/0")
 
 is_public_cidr("::/0")
+
+# is_mysql / is_postgres / is_sqlserver identify the engine family of a
+# google_sql_database_instance resource, used by Cloud SQL policies.
+is_mysql(resource) if startswith(object.get(resource, "database_version", ""), "MYSQL_")
+
+is_postgres(resource) if startswith(object.get(resource, "database_version", ""), "POSTGRES_")
+
+is_sqlserver(resource) if startswith(object.get(resource, "database_version", ""), "SQLSERVER_")


### PR DESCRIPTION
Renames all Rego package declarations from `regofu`/`regofu.lib` to `tofuscan`/`tofuscan.lib` to match the project name, and updates the engine query accordingly.

Also extracts three helpers into `tofuscan.lib` — `is_mysql`, `is_postgres`, and `is_sqlserver` — replacing the repeated inline `startswith` checks across all 15 Cloud SQL policy files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized policy package namespace from `regofu` to `tofuscan` across all GCP and GKE compliance policies
  * Consolidated database type detection logic into shared helper functions for Cloud SQL policies
  * Updated internal policy evaluation query target to reflect new namespace structure

All existing compliance checks and validation rules remain functionally unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osinfra-io/pt-techne-pre-commit-hooks/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->