### PR TITLE
Use full resource address (type.name) to prevent skip and line-number collisions

### DIFF
--- a/internal/tofuscan/engine/engine.go
+++ b/internal/tofuscan/engine/engine.go
@@ -206,14 +206,9 @@ func evaluate(ctx context.Context, file string, input interface{}, prepared rego
 }
 
 // resourceLineIndex scans a file for HCL resource declarations and returns a
-// map of resource label to line number. This is a best-effort text scan — it
-// does not use an HCL parser, so line numbers may be missing for resources
+// map of "type.name" address to line number. This is a best-effort text scan —
+// it does not use an HCL parser, so line numbers may be missing for resources
 // with unusual formatting.
-//
-// Known limitation: resources are keyed by label only, not by type+label. Two
-// resources of different types sharing a label (commonly "this") collide, and
-// the first one scanned wins. The reported line number may then point at the
-// wrong resource. Skip directives in skip.go share the same label-only keying.
 func resourceLineIndex(file string) map[string]int {
 	index := make(map[string]int)
 	f, err := os.Open(file)
@@ -232,9 +227,11 @@ func resourceLineIndex(file string) map[string]int {
 		}
 		parts := strings.Fields(line)
 		if len(parts) >= 3 {
-			name := strings.Trim(parts[2], `"{}`)
-			if _, exists := index[name]; !exists {
-				index[name] = lineNum
+			rtype := strings.Trim(parts[1], `"`)
+			rname := strings.Trim(parts[2], `"{}`)
+			address := rtype + "." + rname
+			if _, exists := index[address]; !exists {
+				index[address] = lineNum
 			}
 		}
 	}

--- a/internal/tofuscan/engine/engine_test.go
+++ b/internal/tofuscan/engine/engine_test.go
@@ -234,11 +234,11 @@ resource "google_compute_firewall" "unrelated_range" {
 		got[v.RuleID] = append(got[v.RuleID], v.Resource)
 	}
 
-	if res := got["gcp/cis/3.6"]; len(res) != 1 || res[0] != "ssh_range" {
-		t.Errorf("gcp/cis/3.6: got %v, want [ssh_range]", res)
+	if res := got["gcp/cis/3.6"]; len(res) != 1 || res[0] != "google_compute_firewall.ssh_range" {
+		t.Errorf("gcp/cis/3.6: got %v, want [google_compute_firewall.ssh_range]", res)
 	}
-	if res := got["gcp/cis/3.7"]; len(res) != 1 || res[0] != "rdp_range" {
-		t.Errorf("gcp/cis/3.7: got %v, want [rdp_range]", res)
+	if res := got["gcp/cis/3.7"]; len(res) != 1 || res[0] != "google_compute_firewall.rdp_range" {
+		t.Errorf("gcp/cis/3.7: got %v, want [google_compute_firewall.rdp_range]", res)
 	}
 }
 
@@ -275,9 +275,9 @@ resource "google_compute_instance" "vm2" {
 	index := resourceLineIndex(f)
 
 	cases := map[string]int{
-		"vm1":    1,
-		"bucket": 5,
-		"vm2":    12,
+		"google_compute_instance.vm1":    1,
+		"google_storage_bucket.bucket":   5,
+		"google_compute_instance.vm2":    12,
 	}
 	for name, wantLine := range cases {
 		if gotLine := index[name]; gotLine != wantLine {
@@ -286,7 +286,7 @@ resource "google_compute_instance" "vm2" {
 	}
 
 	// Non-existent resource returns 0.
-	if line := index["nonexistent"]; line != 0 {
+	if line := index["google_compute_instance.nonexistent"]; line != 0 {
 		t.Errorf("nonexistent resource: got line %d, want 0", line)
 	}
 }
@@ -297,6 +297,34 @@ func TestResourceLineIndexNonexistentFile(t *testing.T) {
 		t.Errorf("expected empty index, got %v", index)
 	}
 }
+
+func TestResourceLineIndexSameLabelDifferentTypes(t *testing.T) {
+	// Two resources share the label "this" but have different types.
+	// Each must resolve to its own correct line number.
+	content := `resource "google_compute_instance" "this" {
+  name = "vm"
+}
+
+resource "google_storage_bucket" "this" {
+  name = "bucket"
+}
+`
+	tmp := t.TempDir()
+	f := tmp + "/test.tofu"
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	index := resourceLineIndex(f)
+
+	if got := index["google_compute_instance.this"]; got != 1 {
+		t.Errorf("google_compute_instance.this: got line %d, want 1", got)
+	}
+	if got := index["google_storage_bucket.this"]; got != 5 {
+		t.Errorf("google_storage_bucket.this: got line %d, want 5", got)
+	}
+}
+
 
 func TestGlobalViolationFiresOnceAcrossFiles(t *testing.T) {
 	// When scanning multiple files where none defines a log sink,

--- a/internal/tofuscan/engine/skip.go
+++ b/internal/tofuscan/engine/skip.go
@@ -99,8 +99,9 @@ func parseFileSkips(file string) map[string]map[string]string {
 		if braceDepth == 0 && strings.HasPrefix(trimmed, "resource ") {
 			parts := strings.Fields(trimmed)
 			if len(parts) >= 3 {
-				name := strings.Trim(parts[2], `"{}`)
-				currentResource = name
+				rtype := strings.Trim(parts[1], `"`)
+				rname := strings.Trim(parts[2], `"{}`)
+				currentResource = rtype + "." + rname
 				braceDepth += countBraces(trimmed)
 				continue
 			}

--- a/internal/tofuscan/engine/skip_test.go
+++ b/internal/tofuscan/engine/skip_test.go
@@ -60,24 +60,24 @@ resource "google_compute_firewall" "allow" {
 
 	resourceLevel := parseFileSkips(f)
 
-	// Resource "primary": CIS 5.5.1 + CIS 5.6.4 (both inside block)
-	primarySkips := resourceLevel["primary"]
+	// Resource "google_container_cluster.primary": CIS 5.5.1 + CIS 5.6.4 (both inside block)
+	primarySkips := resourceLevel["google_container_cluster.primary"]
 	if primarySkips == nil {
-		t.Fatal("expected resource-level skips for 'primary'")
+		t.Fatal("expected resource-level skips for 'google_container_cluster.primary'")
 	}
 	if _, ok := primarySkips["5.5.1"]; !ok {
-		t.Error("expected skip for CIS 5.5.1 on resource 'primary'")
+		t.Error("expected skip for CIS 5.5.1 on resource 'google_container_cluster.primary'")
 	}
 	if _, ok := primarySkips["5.6.4"]; !ok {
-		t.Error("expected skip for CIS 5.6.4 on resource 'primary'")
+		t.Error("expected skip for CIS 5.6.4 on resource 'google_container_cluster.primary'")
 	}
 	if len(primarySkips) != 2 {
-		t.Errorf("expected 2 skips for 'primary', got %d: %v", len(primarySkips), primarySkips)
+		t.Errorf("expected 2 skips for 'google_container_cluster.primary', got %d: %v", len(primarySkips), primarySkips)
 	}
 
-	// Resource "allow": no skips
-	if allowSkips := resourceLevel["allow"]; len(allowSkips) != 0 {
-		t.Errorf("expected no skips for 'allow', got %v", allowSkips)
+	// Resource "google_compute_firewall.allow": no skips
+	if allowSkips := resourceLevel["google_compute_firewall.allow"]; len(allowSkips) != 0 {
+		t.Errorf("expected no skips for 'google_compute_firewall.allow', got %v", allowSkips)
 	}
 }
 
@@ -102,26 +102,26 @@ resource "b" "second" {
 
 	resourceLevel := parseFileSkips(f)
 
-	if firstSkips := resourceLevel["first"]; len(firstSkips) != 0 {
-		t.Errorf("expected no skips for 'first', got %v", firstSkips)
+	if firstSkips := resourceLevel["a.first"]; len(firstSkips) != 0 {
+		t.Errorf("expected no skips for 'a.first', got %v", firstSkips)
 	}
-	if secondSkips := resourceLevel["second"]; len(secondSkips) != 0 {
-		t.Errorf("expected no skips for 'second', got %v", secondSkips)
+	if secondSkips := resourceLevel["b.second"]; len(secondSkips) != 0 {
+		t.Errorf("expected no skips for 'b.second', got %v", secondSkips)
 	}
 }
 
 func TestFilterSkipped(t *testing.T) {
 	violations := []Violation{
-		{File: "a.tofu", Resource: "primary", CISControl: "5.6.4", RuleID: "gke/cis/5.6.4"},
-		{File: "a.tofu", Resource: "primary", CISControl: "5.5.1", RuleID: "gke/cis/5.5.1"},
-		{File: "a.tofu", Resource: "allow", CISControl: "3.3", RuleID: "gcp/cis/3.3"},
+		{File: "a.tofu", Resource: "google_container_cluster.primary", CISControl: "5.6.4", RuleID: "gke/cis/5.6.4"},
+		{File: "a.tofu", Resource: "google_container_cluster.primary", CISControl: "5.5.1", RuleID: "gke/cis/5.5.1"},
+		{File: "a.tofu", Resource: "google_compute_firewall.allow", CISControl: "3.3", RuleID: "gcp/cis/3.3"},
 		{File: "", Resource: "global", CISControl: "2.2", RuleID: "gcp/cis/2.2"},
 	}
 
 	sd := &SkipDirectives{
 		resourceLevel: map[string]map[string]map[string]string{
 			"a.tofu": {
-				"primary": {"5.6.4": "not needed"},
+				"google_container_cluster.primary": {"5.6.4": "not needed"},
 			},
 		},
 	}
@@ -165,12 +165,12 @@ func TestParseFileSkipsNestedBraces(t *testing.T) {
 
 	resourceLevel := parseFileSkips(f)
 
-	primarySkips := resourceLevel["primary"]
+	primarySkips := resourceLevel["google_container_cluster.primary"]
 	if primarySkips == nil || len(primarySkips) != 1 {
-		t.Fatalf("expected 1 skip for 'primary', got %v", primarySkips)
+		t.Fatalf("expected 1 skip for 'google_container_cluster.primary', got %v", primarySkips)
 	}
 	if _, ok := primarySkips["5.6.4"]; !ok {
-		t.Error("expected skip for CIS 5.6.4 on 'primary'")
+		t.Error("expected skip for CIS 5.6.4 on 'google_container_cluster.primary'")
 	}
 }
 
@@ -194,20 +194,20 @@ resource "google_storage_bucket" "bucket" {
 
 	resourceLevel := parseFileSkips(f)
 
-	primarySkips := resourceLevel["primary"]
+	primarySkips := resourceLevel["google_container_cluster.primary"]
 	if primarySkips == nil || len(primarySkips) != 1 {
-		t.Fatalf("expected 1 skip for 'primary', got %v", primarySkips)
+		t.Fatalf("expected 1 skip for 'google_container_cluster.primary', got %v", primarySkips)
 	}
 	if _, ok := primarySkips["5.6.4"]; !ok {
-		t.Error("expected skip for CIS 5.6.4 on 'primary'")
+		t.Error("expected skip for CIS 5.6.4 on 'google_container_cluster.primary'")
 	}
 
-	bucketSkips := resourceLevel["bucket"]
+	bucketSkips := resourceLevel["google_storage_bucket.bucket"]
 	if bucketSkips == nil || len(bucketSkips) != 1 {
-		t.Fatalf("expected 1 skip for 'bucket', got %v", bucketSkips)
+		t.Fatalf("expected 1 skip for 'google_storage_bucket.bucket', got %v", bucketSkips)
 	}
 	if _, ok := bucketSkips["3.3"]; !ok {
-		t.Error("expected skip for CIS 3.3 on 'bucket'")
+		t.Error("expected skip for CIS 3.3 on 'google_storage_bucket.bucket'")
 	}
 }
 
@@ -231,5 +231,39 @@ func TestCountBraces(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("countBraces(%q) = %d, want %d", tc.line, got, tc.want)
 		}
+	}
+}
+
+func TestParseFileSkipsSameLabelDifferentTypes(t *testing.T) {
+	// Two resources share the label "this" but have different types.
+	// A skip inside one block must not apply to the other.
+	content := `resource "google_container_cluster" "this" {
+  # tofu-scan skip: CIS 5.6.4 - cluster skip
+  name = "cluster"
+}
+
+resource "google_storage_bucket" "this" {
+  name = "bucket"
+}
+`
+	tmp := t.TempDir()
+	f := filepath.Join(tmp, "test.tofu")
+	if err := os.WriteFile(f, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resourceLevel := parseFileSkips(f)
+
+	clusterSkips := resourceLevel["google_container_cluster.this"]
+	if clusterSkips == nil || len(clusterSkips) != 1 {
+		t.Fatalf("expected 1 skip for 'google_container_cluster.this', got %v", clusterSkips)
+	}
+	if _, ok := clusterSkips["5.6.4"]; !ok {
+		t.Error("expected skip for CIS 5.6.4 on 'google_container_cluster.this'")
+	}
+
+	bucketSkips := resourceLevel["google_storage_bucket.this"]
+	if len(bucketSkips) != 0 {
+		t.Errorf("expected no skips for 'google_storage_bucket.this', got %v", bucketSkips)
 	}
 }

--- a/internal/tofuscan/policies/gcp/bigquery/7.1.rego
+++ b/internal/tofuscan/policies/gcp/bigquery/7.1.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	some access in resource.access
 	access.special_group in _bq_public_groups
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_bigquery_dataset", name]),
 		"rule_id": "gcp/cis/7.1",
 		"cis_control": "7.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/bigquery/7.2.rego
+++ b/internal/tofuscan/policies/gcp/bigquery/7.2.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some resource in resources
 	not _has_cmek(resource)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_bigquery_table", name]),
 		"rule_id": "gcp/cis/7.2",
 		"cis_control": "7.2",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/bigquery/7.3.rego
+++ b/internal/tofuscan/policies/gcp/bigquery/7.3.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some resource in resources
 	not _has_default_cmek(resource)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_bigquery_dataset", name]),
 		"rule_id": "gcp/cis/7.3",
 		"cis_control": "7.3",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.1.2.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.1.2.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_mysql(resource)
 	not _has_sql_flag(resource, "skip_show_database", "on")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.1.2",
 		"cis_control": "6.1.2",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.1.3.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.1.3.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_mysql(resource)
 	not _has_sql_flag(resource, "local_infile", "off")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.1.3",
 		"cis_control": "6.1.3",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.1.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.1.rego
@@ -21,7 +21,7 @@ deny contains violation if {
 	flag.name == "log_error_verbosity"
 	flag.value in _verbose_values_6_2_1
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.2.1",
 		"cis_control": "6.2.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.2.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.2.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_postgres(resource)
 	not _has_pg_flag_on(resource, "log_connections")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.2.2",
 		"cis_control": "6.2.2",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.3.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.3.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_postgres(resource)
 	not _has_pg_flag_on(resource, "log_disconnections")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.2.3",
 		"cis_control": "6.2.3",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.4.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.4.rego
@@ -18,7 +18,7 @@ deny contains violation if {
 	lib.is_postgres(resource)
 	not _has_acceptable_log_statement(resource)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.2.4",
 		"cis_control": "6.2.4",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.5.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.5.rego
@@ -26,7 +26,7 @@ deny contains violation if {
 	flag.name == "log_min_messages"
 	flag.value in _too_verbose_6_2_5
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.2.5",
 		"cis_control": "6.2.5",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.6.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.6.rego
@@ -27,7 +27,7 @@ deny contains violation if {
 	flag.name == "log_min_error_statement"
 	flag.value in _too_verbose_6_2_6
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.2.6",
 		"cis_control": "6.2.6",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.7.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.7.rego
@@ -19,7 +19,7 @@ deny contains violation if {
 	flag.name == "log_min_duration_statement"
 	flag.value != "-1"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.2.7",
 		"cis_control": "6.2.7",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.2.8.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.2.8.rego
@@ -16,7 +16,7 @@ deny contains violation if {
 	lib.is_postgres(resource)
 	not _has_pg_flag_on(resource, "cloudsql.enable_pgaudit")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.2.8",
 		"cis_control": "6.2.8",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.1.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.1.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "external scripts enabled", "off")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.3.1",
 		"cis_control": "6.3.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.2.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.2.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "cross db ownership chaining", "off")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.3.2",
 		"cis_control": "6.3.2",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.5.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.5.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "remote access", "off")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.3.5",
 		"cis_control": "6.3.5",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.6.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.6.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "3625", "on")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.3.6",
 		"cis_control": "6.3.6",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.7.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.7.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	lib.is_sqlserver(resource)
 	not _has_sql_flag(resource, "contained database authentication", "off")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.3.7",
 		"cis_control": "6.3.7",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.4.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.4.rego
@@ -17,7 +17,7 @@ deny contains violation if {
 	object.get(ip_config, "ssl_mode", "ALLOW_UNENCRYPTED_AND_ENCRYPTED") == "ALLOW_UNENCRYPTED_AND_ENCRYPTED"
 	object.get(ip_config, "require_ssl", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.4",
 		"cis_control": "6.4",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.5.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.5.rego
@@ -17,7 +17,7 @@ deny contains violation if {
 	some network in networks
 	network.value == "0.0.0.0/0"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.5",
 		"cis_control": "6.5",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.7.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.7.rego
@@ -16,7 +16,7 @@ deny contains violation if {
 	some ip_config in ip_config_arr
 	object.get(ip_config, "ipv4_enabled", true) == true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.7",
 		"cis_control": "6.7",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.8.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.8.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	some backup in backup_configs
 	object.get(backup, "enabled", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_sql_database_instance", name]),
 		"rule_id": "gcp/cis/6.8",
 		"cis_control": "6.8",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/iam/1.10.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.10.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	some resource in resources
 	resource.member in _public_members_1_10
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_kms_crypto_key_iam_member", name]),
 		"rule_id": "gcp/cis/1.10",
 		"cis_control": "1.10",
 		"profile_level": "Level 1",
@@ -31,7 +31,7 @@ deny contains violation if {
 	some member in resource.members
 	member in _public_members_1_10
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_kms_crypto_key_iam_binding", name]),
 		"rule_id": "gcp/cis/1.10",
 		"cis_control": "1.10",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/iam/1.11.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.11.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	some resource in resources
 	not resource.rotation_period
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_kms_crypto_key", name]),
 		"rule_id": "gcp/cis/1.11",
 		"cis_control": "1.11",
 		"profile_level": "Level 1",
@@ -36,7 +36,7 @@ deny contains violation if {
 	seconds := to_number(seconds_str)
 	seconds > _max_rotation_seconds
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_kms_crypto_key", name]),
 		"rule_id": "gcp/cis/1.11",
 		"cis_control": "1.11",
 		"profile_level": "Level 1",
@@ -53,7 +53,7 @@ deny contains violation if {
 	period != ""
 	not regex.match(`^[0-9]+(?:\.[0-9]{1,9})?s$`, period)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_kms_crypto_key", name]),
 		"rule_id": "gcp/cis/1.11",
 		"cis_control": "1.11",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/iam/1.6.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.6.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	startswith(resource.member, "serviceAccount:")
 	resource.role in _admin_roles
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_project_iam_member", name]),
 		"rule_id": "gcp/cis/1.6",
 		"cis_control": "1.6",
 		"profile_level": "Level 1",
@@ -32,7 +32,7 @@ deny contains violation if {
 	startswith(member, "serviceAccount:")
 	resource.role in _admin_roles
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_project_iam_binding", name]),
 		"rule_id": "gcp/cis/1.6",
 		"cis_control": "1.6",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/iam/1.7.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.7.rego
@@ -19,7 +19,7 @@ deny contains violation if {
 	some resource in resources
 	resource.role in _sa_roles_1_7
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_project_iam_member", name]),
 		"rule_id": "gcp/cis/1.7",
 		"cis_control": "1.7",
 		"profile_level": "Level 1",
@@ -34,7 +34,7 @@ deny contains violation if {
 	some resource in resources
 	resource.role in _sa_roles_1_7
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_project_iam_binding", name]),
 		"rule_id": "gcp/cis/1.7",
 		"cis_control": "1.7",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/iam/1.8.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.8.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	key_type := object.get(resource, "key_type", "USER_MANAGED")
 	key_type == "USER_MANAGED"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_iam_service_account_key", name]),
 		"rule_id": "gcp/cis/1.8",
 		"cis_control": "1.8",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/networking/3.1.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.1.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some resource in resources
 	resource.name == "default"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_network", name]),
 		"rule_id": "gcp/cis/3.1",
 		"cis_control": "3.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/networking/3.10.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.10.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	not log_config_enabled(resource)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_subnetwork", name]),
 		"rule_id": "gcp/cis/3.10",
 		"cis_control": "3.10",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/networking/3.11.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.11.rego
@@ -16,7 +16,7 @@ deny contains violation if {
 	min_tls := object.get(resource, "min_tls_version", "TLS_1_0")
 	min_tls in _weak_tls_versions
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_ssl_policy", name]),
 		"rule_id": "gcp/cis/3.11",
 		"cis_control": "3.11",
 		"profile_level": "Level 1",
@@ -32,7 +32,7 @@ deny contains violation if {
 	profile := object.get(resource, "profile", "COMPATIBLE")
 	profile == "COMPATIBLE"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_ssl_policy", name]),
 		"rule_id": "gcp/cis/3.11",
 		"cis_control": "3.11",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/networking/3.3.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.3.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	not dnssec_enabled(resource)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_dns_managed_zone", name]),
 		"rule_id": "gcp/cis/3.3",
 		"cis_control": "3.3",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/networking/3.4.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.4.rego
@@ -16,7 +16,7 @@ deny contains violation if {
 	some spec in key_specs
 	spec.algorithm == "rsasha1"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_dns_managed_zone", name]),
 		"rule_id": "gcp/cis/3.4",
 		"cis_control": "3.4",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/networking/3.6.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.6.rego
@@ -18,7 +18,7 @@ deny contains violation if {
 	some cidr in resource.source_ranges
 	lib.is_public_cidr(cidr)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_firewall", name]),
 		"rule_id": "gcp/cis/3.6",
 		"cis_control": "3.6",
 		"profile_level": "Level 1",
@@ -37,7 +37,7 @@ deny contains violation if {
 	some cidr in resource.source_ranges
 	lib.is_public_cidr(cidr)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_firewall", name]),
 		"rule_id": "gcp/cis/3.6",
 		"cis_control": "3.6",
 		"profile_level": "Level 1",
@@ -55,7 +55,7 @@ deny contains violation if {
 	some cidr in resource.source_ranges
 	lib.is_public_cidr(cidr)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_firewall", name]),
 		"rule_id": "gcp/cis/3.6",
 		"cis_control": "3.6",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/networking/3.7.rego
+++ b/internal/tofuscan/policies/gcp/networking/3.7.rego
@@ -18,7 +18,7 @@ deny contains violation if {
 	some cidr in resource.source_ranges
 	lib.is_public_cidr(cidr)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_firewall", name]),
 		"rule_id": "gcp/cis/3.7",
 		"cis_control": "3.7",
 		"profile_level": "Level 2",
@@ -37,7 +37,7 @@ deny contains violation if {
 	some cidr in resource.source_ranges
 	lib.is_public_cidr(cidr)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_firewall", name]),
 		"rule_id": "gcp/cis/3.7",
 		"cis_control": "3.7",
 		"profile_level": "Level 2",
@@ -55,7 +55,7 @@ deny contains violation if {
 	some cidr in resource.source_ranges
 	lib.is_public_cidr(cidr)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_firewall", name]),
 		"rule_id": "gcp/cis/3.7",
 		"cis_control": "3.7",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/storage/5.1.rego
+++ b/internal/tofuscan/policies/gcp/storage/5.1.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	some resource in resources
 	resource.member in _public_members
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_storage_bucket_iam_member", name]),
 		"rule_id": "gcp/cis/5.1",
 		"cis_control": "5.1",
 		"profile_level": "Level 1",
@@ -30,7 +30,7 @@ deny contains violation if {
 	some member in resource.members
 	member in _public_members
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_storage_bucket_iam_binding", name]),
 		"rule_id": "gcp/cis/5.1",
 		"cis_control": "5.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/storage/5.2.rego
+++ b/internal/tofuscan/policies/gcp/storage/5.2.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	object.get(resource, "uniform_bucket_level_access", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_storage_bucket", name]),
 		"rule_id": "gcp/cis/5.2",
 		"cis_control": "5.2",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.1.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.1.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	not resource.service_account
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.1",
 		"cis_control": "4.1",
 		"profile_level": "Level 1",
@@ -29,7 +29,7 @@ deny contains violation if {
 	email := lower(object.get(sa, "email", ""))
 	email == ""
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.1",
 		"cis_control": "4.1",
 		"profile_level": "Level 1",
@@ -46,7 +46,7 @@ deny contains violation if {
 	email := lower(object.get(sa, "email", ""))
 	endswith(email, "-compute@developer.gserviceaccount.com")
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.1",
 		"cis_control": "4.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.11.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.11.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	not resource.confidential_instance_config
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.11",
 		"cis_control": "4.11",
 		"profile_level": "Level 2",
@@ -28,7 +28,7 @@ deny contains violation if {
 	some config in resource.confidential_instance_config
 	object.get(config, "enable_confidential_compute", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.11",
 		"cis_control": "4.11",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.2.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.2.rego
@@ -25,7 +25,7 @@ deny contains violation if {
 	some scope in sa.scopes
 	scope in _cloud_platform_full_scopes
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.2",
 		"cis_control": "4.2",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.3.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.3.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	object.get(metadata, "block-project-ssh-keys", "false") != "true"
 	object.get(metadata, "enable-oslogin", "false") != "true"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.3",
 		"cis_control": "4.3",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.4.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.4.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some resource in resources
 	not _oslogin_effective(resource)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.4",
 		"cis_control": "4.4",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.5.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.5.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	val := object.get(metadata, "serial-port-enable", "false")
 	val == "true"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.5",
 		"cis_control": "4.5",
 		"profile_level": "Level 1",
@@ -31,7 +31,7 @@ deny contains violation if {
 	val := object.get(metadata, "serial-port-enable", "false")
 	val == "1"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.5",
 		"cis_control": "4.5",
 		"profile_level": "Level 1",
@@ -48,7 +48,7 @@ deny contains violation if {
 	val := object.get(metadata, "serial-port-enable", false)
 	val == true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.5",
 		"cis_control": "4.5",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.6.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.6.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	resource.can_ip_forward == true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.6",
 		"cis_control": "4.6",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.7.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.7.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some resource in resources
 	not _has_csek(resource)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_disk", name]),
 		"rule_id": "gcp/cis/4.7",
 		"cis_control": "4.7",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.8.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.8.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	some cfg in config_arr
 	not _shielded_vm_ok(cfg)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.8",
 		"cis_control": "4.8",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gcp/virtual_machines/4.9.rego
+++ b/internal/tofuscan/policies/gcp/virtual_machines/4.9.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	access_configs := object.get(iface, "access_config", [])
 	count(access_configs) > 0
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_compute_instance", name]),
 		"rule_id": "gcp/cis/4.9",
 		"cis_control": "4.9",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gke/auth/5.8.1.rego
+++ b/internal/tofuscan/policies/gke/auth/5.8.1.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	some ccc in object.get(ma, "client_certificate_config", [{}])
 	ccc.issue_client_certificate == true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.8.1",
 		"cis_control": "5.8.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/auth/5.8.3.rego
+++ b/internal/tofuscan/policies/gke/auth/5.8.3.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	resource.enable_legacy_abac == true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.8.3",
 		"cis_control": "5.8.3",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/iam/5.2.1.rego
+++ b/internal/tofuscan/policies/gke/iam/5.2.1.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	sa := lower(object.get(nc, "service_account", "default"))
 	_is_default_gke_sa(sa)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_node_pool", name]),
 		"rule_id": "gke/cis/5.2.1",
 		"cis_control": "5.2.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/kms/5.3.1.rego
+++ b/internal/tofuscan/policies/gke/kms/5.3.1.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	some enc in enc_arr
 	object.get(enc, "state", "DECRYPTED") != "ENCRYPTED"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.3.1",
 		"cis_control": "5.3.1",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gke/logging/5.7.1.rego
+++ b/internal/tofuscan/policies/gke/logging/5.7.1.rego
@@ -17,7 +17,7 @@ deny contains violation if {
 	some resource in resources
 	resource.logging_service == "none"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.7.1",
 		"cis_control": "5.7.1",
 		"profile_level": "Level 1",
@@ -32,7 +32,7 @@ deny contains violation if {
 	some resource in resources
 	resource.monitoring_service == "none"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.7.1",
 		"cis_control": "5.7.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/networking/5.6.1.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.1.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some resource in resources
 	object.get(resource, "enable_intranode_visibility", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.6.1",
 		"cis_control": "5.6.1",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gke/networking/5.6.2.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.2.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	not _is_vpc_native(resource)
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.6.2",
 		"cis_control": "5.6.2",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/networking/5.6.3.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.3.rego
@@ -15,7 +15,7 @@ deny contains violation if {
 	cidr_blocks := object.get(manc, "cidr_blocks", [])
 	count(cidr_blocks) == 0
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.6.3",
 		"cis_control": "5.6.3",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/networking/5.6.4.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.4.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some pcc in object.get(resource, "private_cluster_config", [{}])
 	object.get(pcc, "enable_private_endpoint", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.6.4",
 		"cis_control": "5.6.4",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gke/networking/5.6.5.rego
+++ b/internal/tofuscan/policies/gke/networking/5.6.5.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some pcc in object.get(resource, "private_cluster_config", [{}])
 	object.get(pcc, "enable_private_nodes", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.6.5",
 		"cis_control": "5.6.5",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.1.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.1.rego
@@ -21,7 +21,7 @@ deny contains violation if {
 	not startswith(image_type_val, "${")
 	upper(image_type_val) != "COS_CONTAINERD"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_node_pool", name]),
 		"rule_id": "gke/cis/5.5.1",
 		"cis_control": "5.5.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.2.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.2.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some mgmt in object.get(resource, "management", [{}])
 	object.get(mgmt, "auto_repair", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_node_pool", name]),
 		"rule_id": "gke/cis/5.5.2",
 		"cis_control": "5.5.2",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.3.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.3.rego
@@ -13,7 +13,7 @@ deny contains violation if {
 	some mgmt in object.get(resource, "management", [{}])
 	object.get(mgmt, "auto_upgrade", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_node_pool", name]),
 		"rule_id": "gke/cis/5.5.3",
 		"cis_control": "5.5.3",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.4.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.4.rego
@@ -16,7 +16,7 @@ deny contains violation if {
 	channel := object.get(rc, "channel", "UNSPECIFIED")
 	not channel in _valid_channels
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.5.4",
 		"cis_control": "5.5.4",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.5.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.5.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	object.get(resource, "enable_shielded_nodes", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.5.5",
 		"cis_control": "5.5.5",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.6.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.6.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	some sic in object.get(nc, "shielded_instance_config", [{}])
 	object.get(sic, "enable_integrity_monitoring", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_node_pool", name]),
 		"rule_id": "gke/cis/5.5.6",
 		"cis_control": "5.5.6",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gke/node_configuration/5.5.7.rego
+++ b/internal/tofuscan/policies/gke/node_configuration/5.5.7.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	some sic in object.get(nc, "shielded_instance_config", [{}])
 	object.get(sic, "enable_secure_boot", false) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_node_pool", name]),
 		"rule_id": "gke/cis/5.5.7",
 		"cis_control": "5.5.7",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gke/node_metadata/5.4.1.rego
+++ b/internal/tofuscan/policies/gke/node_metadata/5.4.1.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	some wmc in object.get(nc, "workload_metadata_config", [{}])
 	object.get(wmc, "mode", "") != "GKE_METADATA"
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_node_pool", name]),
 		"rule_id": "gke/cis/5.4.1",
 		"cis_control": "5.4.1",
 		"profile_level": "Level 2",

--- a/internal/tofuscan/policies/gke/other/5.10.1.rego
+++ b/internal/tofuscan/policies/gke/other/5.10.1.rego
@@ -14,7 +14,7 @@ deny contains violation if {
 	some dashboard in object.get(addons, "kubernetes_dashboard", [])
 	object.get(dashboard, "disabled", true) != true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.10.1",
 		"cis_control": "5.10.1",
 		"profile_level": "Level 1",

--- a/internal/tofuscan/policies/gke/other/5.10.2.rego
+++ b/internal/tofuscan/policies/gke/other/5.10.2.rego
@@ -12,7 +12,7 @@ deny contains violation if {
 	some resource in resources
 	resource.enable_kubernetes_alpha == true
 	violation := {
-		"resource": name,
+		"resource": concat(".", ["google_container_cluster", name]),
 		"rule_id": "gke/cis/5.10.2",
 		"cis_control": "5.10.2",
 		"profile_level": "Level 1",


### PR DESCRIPTION
Fixes #33

## What changed

Resources are now keyed by their full address (e.g. `google_container_cluster.primary`) instead of just the label (`primary`). This fixes two bugs that occurred when two resources of different types shared the same label:

- **Skip directives could suppress violations on the wrong resource** — a skip for `google_container_cluster.primary` could unintentionally suppress a finding on `google_compute_firewall.primary`
- **`resourceLineIndex` reported the wrong line number** — the index was keyed by label so both resources mapped to the same entry

## Changes

- **66 Rego policies**: `"resource": name` → `"resource": concat(".", ["type", name])` in every `deny` block
- **`resourceLineIndex`** (engine.go): keys by `type.name` instead of label; first-write-wins guard retained since the scanner is text-based
- **`parseFileSkips`** (skip.go): builds key as `type.name` when entering a resource block
- **Regression tests**: added `TestResourceLineIndexSameLabelDifferentTypes` and `TestParseFileSkipsSameLabelDifferentTypes`
- Existing tests updated to use full addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Resource identification in compliance violations now uses fully-qualified names** – Violations now report resources using the `type.name` format (e.g., `google_compute_firewall.my-firewall`) instead of labels alone, eliminating ambiguity when different resource types share the same label.

* **Improved resource mapping and skip directive matching** – Resource line indexing and skip filtering now consistently use fully-qualified identifiers to ensure accurate targeting of specific resources across all compliance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->