### PR TITLE
Add regal-lint pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -35,3 +35,11 @@
   pass_filenames: false
   language: golang
   name: tofu scan
+
+- id: regal-lint
+  description: Lint Rego policies using Regal, the linter for Open Policy Agent (OPA).
+  entry: regallint
+  exclude: \.terraform/.*$
+  files: \.rego$
+  language: golang
+  name: regal lint

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Runs `tofu test` to execute automated tests defined in `.tftest.hcl` files. This
 
 Runs `tofuscan` to check your OpenTofu (`.tofu`) files against CIS benchmark policies using OPA/Rego. Covers CIS Google Cloud Platform Foundation Benchmark v5.0.0 (47 policies) and CIS Google Kubernetes Engine (GKE) Benchmark v1.8.0 (20 policies). It will not scan files in `.terraform/` directories.
 
+### regal-lint
+
+#### Lints Rego policies using Regal
+
+Runs `regal lint` to check your Rego (`.rego`) policy files against Regal's built-in linting rules. Catches style violations, deprecated constructs, and common mistakes in OPA/Rego code. It will not lint files in `.terraform/` directories.
+
 ---
 
 ## Usage
@@ -105,6 +111,22 @@ resource "google_compute_firewall" "allow_ssh" {
 ```
 
 The format is `# tofu-scan skip: CIS <control> [- <reason>]`. Skip comments placed outside a resource block are ignored. Skipped violations appear in the output summary so they remain visible.
+
+### Example: `regal-lint`
+
+Lints Rego policy files using [Regal](https://docs.styra.com/regal).
+
+```yaml
+- repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
+  rev: <release-or-commit-sha>
+  hooks:
+    - id: regal-lint
+      # Optional: pass additional args to regal lint
+      # args: ["--fail-level", "warning"]  # also fail on warnings (default: error)
+      # args: ["--config-file", ".regal.yaml"]  # use a specific config file
+```
+
+Regal is triggered on `.rego` file changes. It respects any `.regal.yaml` configuration file in your repository.
 
 Replace `<release-or-commit-sha>` with the desired version or commit hash.
 

--- a/cmd/regallint/main.go
+++ b/cmd/regallint/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"pre-commit-hooks/internal/regallint"
+)
+
+func main() {
+	err := RunRegalLintCLI(
+		os.Args[1:],
+		regallint.CheckRegalInstalled,
+		regallint.RunRegalLint,
+	)
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+// RunRegalLintCLI runs the regal lint CLI logic. Returns error if any step fails.
+func RunRegalLintCLI(
+	args []string,
+	checkInstalled func() bool,
+	runLint func([]string) (string, error),
+) error {
+	if !checkInstalled() {
+		fmt.Println("Regal is not installed or not in PATH.")
+		return fmt.Errorf("regal not installed")
+	}
+
+	hasFiles := false
+	for _, arg := range args {
+		if !strings.HasPrefix(arg, "-") {
+			hasFiles = true
+			break
+		}
+	}
+
+	if !hasFiles {
+		fmt.Println("No Rego files to lint.")
+		return nil
+	}
+
+	out, err := runLint(args)
+	if out != "" {
+		fmt.Print(out)
+	}
+	return err
+}

--- a/cmd/regallint/main_test.go
+++ b/cmd/regallint/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRunRegalLintCLI_NotInstalled(t *testing.T) {
+	checkInstalled := func() bool { return false }
+	runLint := func(args []string) (string, error) { return "", nil }
+
+	err := RunRegalLintCLI([]string{"policy.rego"}, checkInstalled, runLint)
+	if err == nil {
+		t.Error("Expected error when regal is not installed, got nil")
+	}
+}
+
+func TestRunRegalLintCLI_NoFiles(t *testing.T) {
+	checkInstalled := func() bool { return true }
+	runLint := func(args []string) (string, error) { return "", nil }
+
+	err := RunRegalLintCLI([]string{}, checkInstalled, runLint)
+	if err != nil {
+		t.Errorf("Expected nil when no files provided, got: %v", err)
+	}
+}
+
+func TestRunRegalLintCLI_OnlyFlags(t *testing.T) {
+	checkInstalled := func() bool { return true }
+	runLint := func(args []string) (string, error) { return "", nil }
+
+	err := RunRegalLintCLI([]string{"--fail-level", "warning"}, checkInstalled, runLint)
+	if err != nil {
+		t.Errorf("Expected nil when only flags provided (no files), got: %v", err)
+	}
+}
+
+func TestRunRegalLintCLI_LintError(t *testing.T) {
+	checkInstalled := func() bool { return true }
+	runLint := func(args []string) (string, error) {
+		return "violations found\n", fmt.Errorf("exit status 1")
+	}
+
+	err := RunRegalLintCLI([]string{"policy.rego"}, checkInstalled, runLint)
+	if err == nil {
+		t.Error("Expected error when regal reports violations, got nil")
+	}
+}
+
+func TestRunRegalLintCLI_AllOk(t *testing.T) {
+	checkInstalled := func() bool { return true }
+	runLint := func(args []string) (string, error) { return "", nil }
+
+	err := RunRegalLintCLI([]string{"policy.rego"}, checkInstalled, runLint)
+	if err != nil {
+		t.Errorf("Expected nil when no violations, got: %v", err)
+	}
+}
+
+func TestRunRegalLintCLI_ExtraFlagsAndFiles(t *testing.T) {
+	checkInstalled := func() bool { return true }
+
+	var capturedArgs []string
+	runLint := func(args []string) (string, error) {
+		capturedArgs = args
+		return "", nil
+	}
+
+	err := RunRegalLintCLI([]string{"--fail-level", "warning", "policy.rego"}, checkInstalled, runLint)
+	if err != nil {
+		t.Errorf("Expected nil, got: %v", err)
+	}
+	if len(capturedArgs) != 3 {
+		t.Errorf("Expected 3 args passed to runLint, got %d: %v", len(capturedArgs), capturedArgs)
+	}
+}

--- a/internal/regallint/regallint.go
+++ b/internal/regallint/regallint.go
@@ -1,0 +1,20 @@
+package regallint
+
+import (
+	"os/exec"
+
+	"pre-commit-hooks/internal/testutil"
+)
+
+// CheckRegalInstalled delegates to shared testutil implementation.
+var CheckRegalInstalled = testutil.CheckRegalInstalled
+
+// RunRegalLint runs regal lint with the provided args (flags and/or file paths).
+// Returns combined output and error.
+func RunRegalLint(args []string) (string, error) {
+	a := append([]string{"lint"}, args...)
+	// no-dd-sa:go-security/command-injection - https://github.com/osinfra-io/pt-techne-pre-commit-hooks/issues/8
+	cmd := exec.Command("regal", a...)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}

--- a/internal/regallint/regallint_test.go
+++ b/internal/regallint/regallint_test.go
@@ -1,0 +1,58 @@
+package regallint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"pre-commit-hooks/internal/testutil"
+)
+
+func TestRunRegalLint_Clean(t *testing.T) {
+	testutil.SkipIfRegalNotInstalled(t)
+	tempDir, cleanup := testutil.CreateTempDir(t, "regallint_clean")
+	defer cleanup()
+
+	// Create a subdirectory matching the package name to satisfy directory-package-mismatch.
+	policyDir := filepath.Join(tempDir, "example")
+	if err := os.Mkdir(policyDir, 0755); err != nil {
+		t.Fatalf("Failed to create policy dir: %v", err)
+	}
+
+	// Use a minimal, properly formatted policy with no violations.
+	policy := "package example\n\nimport rego.v1\n"
+	filePath := filepath.Join(policyDir, "policy.rego")
+	if err := os.WriteFile(filePath, []byte(policy), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	out, err := RunRegalLint([]string{filePath})
+	if err != nil {
+		t.Fatalf("Expected clean policy to pass regal lint, got error: %v\nOutput: %s", err, out)
+	}
+}
+
+func TestRunRegalLint_Violations(t *testing.T) {
+	testutil.SkipIfRegalNotInstalled(t)
+	tempDir, cleanup := testutil.CreateTempDir(t, "regallint_violations")
+	defer cleanup()
+
+	// opa-fmt rule: unformatted Rego triggers a violation
+	policy := `package example
+
+import rego.v1
+
+deny[msg] {
+	msg = "example violation"
+}
+`
+	filePath := filepath.Join(tempDir, "policy.rego")
+	if err := os.WriteFile(filePath, []byte(policy), 0644); err != nil {
+		t.Fatalf("Failed to write test file: %v", err)
+	}
+
+	out, err := RunRegalLint([]string{filePath})
+	if err == nil {
+		t.Fatalf("Expected policy with violations to fail regal lint, but it passed\nOutput: %s", out)
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -12,10 +12,23 @@ func CheckOpenTofuInstalled() bool {
 	return err == nil
 }
 
+// CheckRegalInstalled returns true if the 'regal' binary is found in PATH.
+func CheckRegalInstalled() bool {
+	_, err := exec.LookPath("regal")
+	return err == nil
+}
+
 // SkipIfTofuNotInstalled skips the test if tofu is not installed
 func SkipIfTofuNotInstalled(t *testing.T) {
 	if !CheckOpenTofuInstalled() {
 		t.Skip("Skipping test as tofu is not installed")
+	}
+}
+
+// SkipIfRegalNotInstalled skips the test if regal is not installed.
+func SkipIfRegalNotInstalled(t *testing.T) {
+	if !CheckRegalInstalled() {
+		t.Skip("Skipping test as regal is not installed")
 	}
 }
 

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -13,6 +13,13 @@ func TestCheckOpenTofuInstalled(t *testing.T) {
 	}
 }
 
+func TestCheckRegalInstalled(t *testing.T) {
+	SkipIfRegalNotInstalled(t)
+	if !CheckRegalInstalled() {
+		t.Error("CheckRegalInstalled should return true when regal is installed")
+	}
+}
+
 func TestCreateTempDir(t *testing.T) {
 	dir, cleanup := CreateTempDir(t, "testutil_temp_")
 	defer cleanup()


### PR DESCRIPTION
Closes #61

## Summary

Adds a new `regal-lint` hook that runs `regal lint` on `.rego` file changes, catching Rego policy violations locally before CI.

## Changes

- **`cmd/regallint/`** — new Go binary entry point with dependency-injected `RunRegalLintCLI`
- **`internal/regallint/`** — core `RunRegalLint` logic and tests (skip if regal not installed)
- **`internal/testutil/`** — add `CheckRegalInstalled` and `SkipIfRegalNotInstalled` helpers
- **`.pre-commit-hooks.yaml`** — register the new `regal-lint` hook (files: `\.rego$`, excludes `.terraform/`)
- **`README.md`** — document the new hook with usage examples

## Usage

```yaml
- repo: https://github.com/osinfra-io/pt-techne-pre-commit-hooks
  rev: <release-or-commit-sha>
  hooks:
    - id: regal-lint
```

Extra flags (e.g. `--fail-level warning`, `--config-file .regal.yaml`) are supported via the hook's `args:` config and are passed directly to `regal lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `regal-lint` pre-commit hook for linting OPA Rego policy files. Automatically runs on `.rego` files while excluding `.terraform/` directories and respects local `.regal.yaml` configuration.

* **Documentation**
  * Updated README with `regal-lint` hook configuration examples and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->