### PR TITLE
Add regal lint as a local pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@ repos:
       - id: regal-lint
         name: regal lint
         entry: regal lint internal/tofuscan/policies
-        language: system
-        files: \.rego$
+        language: system  # requires regal to be installed locally (see StyraInc/setup-regal in CI)
+        files: internal/tofuscan/policies/.*\.rego$
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-symlinks
+
+  - repo: local
+    hooks:
+      - id: regal-lint
+        name: regal lint
+        entry: regal lint internal/tofuscan/policies
+        language: system
+        files: \.rego$
+        pass_filenames: false


### PR DESCRIPTION
Closes #61

Adds a local pre-commit hook that runs `regal lint internal/tofuscan/policies` when `.rego` files change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated pre-commit lint hook for policy files, providing immediate feedback on formatting and standards before commits to help maintain consistency and reduce commit-time issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->