### PR TITLE
Add Rego policies for CIS controls 1.5, 6.3.3, 6.3.4, 8.1, 5.9.1, 5.9.2, 5.10.3

### DIFF
--- a/docs/tofuscan/cis-gcp-v5.0.0.md
+++ b/docs/tofuscan/cis-gcp-v5.0.0.md
@@ -55,7 +55,7 @@ cryptographic keys, and protecting API credentials.
 | 1.2 | Level 1 | Ensure that Corporate Login Credentials are Used | Manual | | Use corporate login credentials instead of consumer accounts such as Gmail accounts, ensuring visibility and auditing over access. |
 | 1.3 | Level 1 | Ensure that Multi-Factor Authentication is Enabled for All Non-Service Accounts | Manual | | Require MFA for all user accounts to protect against credential compromise. |
 | 1.4 | Level 1 | Ensure that Security Key Enforcement is Enabled for All Admin Accounts | Manual | | Require phishing-resistant hardware security keys for all admin accounts. |
-| 1.5 | Level 1 | Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account | Automated | | User-managed service account keys are difficult to rotate and audit; only GCP-managed keys should be used. |
+| 1.5 | Level 1 | Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account | Automated | ✅ | User-managed service account keys are difficult to rotate and audit; only GCP-managed keys should be used. |
 | 1.6 | Level 1 | Ensure That Service Account Has No Admin Privileges | Automated | ✅ | Service accounts should use the minimum necessary permissions; admin roles grant overly broad access to all GCP services. |
 | 1.7 | Level 1 | Ensure That IAM Users Are Not Assigned the Service Account User or Service Account Token Creator Roles at Project Level | Automated | ✅ | Assign the `serviceAccountUser` and `serviceAccountTokenCreator` roles at the service account level, not the project level, to limit blast radius. |
 | 1.8 | Level 1 | Ensure User-Managed/External Keys for Service Accounts Are Rotated Every 90 Days or Fewer | Automated | ✅ | Service Account keys used to authenticate API requests must be rotated regularly to limit exposure from key compromise. |
@@ -185,8 +185,8 @@ to prevent unauthorized access and data loss.
 | 6.2.8 | Level 1 | Ensure That cloudsql.enable_pgaudit Database Flag for each Cloud SQL PostgreSQL Instance Is Set to On | Automated | ✅ | The `pgaudit` extension provides detailed session and object audit logging required for compliance with standards like PCI DSS and HIPAA. |
 | 6.3.1 | Level 1 | Ensure external scripts enabled Database Flag for Cloud SQL SQL Server Instance Is Set to Off | Automated | ✅ | Disabling `external scripts enabled` prevents execution of scripts in external languages (e.g., Python, R) which can be exploited for code execution. |
 | 6.3.2 | Level 1 | Ensure That the cross db ownership chaining Database Flag for Cloud SQL SQL Server Instance Is Set to Off | Automated | ✅ | Cross-database ownership chaining can allow users to access objects in other databases. It should be disabled unless explicitly required. |
-| 6.3.3 | Level 1 | Ensure user Connections Database Flag for Cloud SQL SQL Server Instance Is Set to a Non-limiting Value | Automated | | The `user connections` flag should be set to 0 (unlimited) to prevent denial of service from connection limits while still allowing monitoring. |
-| 6.3.4 | Level 1 | Ensure user options Database Flag for Cloud SQL SQL Server Instance Is Not Configured | Automated | | The `user options` flag sets global defaults for all user sessions, which can override per-session settings and create unpredictable behavior. |
+| 6.3.3 | Level 1 | Ensure user Connections Database Flag for Cloud SQL SQL Server Instance Is Set to a Non-limiting Value | Automated | ✅ | The `user connections` flag should be set to 0 (unlimited) to prevent denial of service from connection limits while still allowing monitoring. |
+| 6.3.4 | Level 1 | Ensure user options Database Flag for Cloud SQL SQL Server Instance Is Not Configured | Automated | ✅ | The `user options` flag sets global defaults for all user sessions, which can override per-session settings and create unpredictable behavior. |
 | 6.3.5 | Level 1 | Ensure remote access Database Flag for Cloud SQL SQL Server Instance Is Set to Off | Automated | ✅ | Disabling remote access prevents the SQL Server instance from executing stored procedures on remote servers, reducing the attack surface. |
 | 6.3.6 | Level 1 | Ensure 3625 (trace flag) Database Flag for all Cloud SQL Server Instances Is Set to On | Automated | ✅ | Trace flag 3625 masks error message details shown to non-admin users, preventing information disclosure of internal SQL Server state. |
 | 6.3.7 | Level 1 | Ensure That the contained database authentication Database Flag for Cloud SQL SQL Server Instance Is Set to Off | Automated | ✅ | Contained databases can authenticate users without domain-level credentials, which can bypass organizational authentication policies. |
@@ -223,7 +223,7 @@ unauthorized access.
 
 | Control | Level | Title | Type | Covered | Description |
 | --------- | ------- | ------- | ------ | --------- | ------------- |
-| 8.1 | Level 2 | Ensure that Dataproc Cluster is Encrypted Using Customer-Managed Encryption Key | Automated | | Dataproc cluster data on Persistent Disks should be encrypted with CMEK so that the organization controls the key lifecycle and can revoke access independently of GCP. |
+| 8.1 | Level 2 | Ensure that Dataproc Cluster is Encrypted Using Customer-Managed Encryption Key | Automated | ✅ | Dataproc cluster data on Persistent Disks should be encrypted with CMEK so that the organization controls the key lifecycle and can revoke access independently of GCP. |
 
 ---
 
@@ -231,4 +231,4 @@ unauthorized access.
 
 | Total Controls | Automated | Manual | Implemented |
 | ---------------- | ----------- | -------- | ------------- |
-| 93 | 71 | 22 | 47 |
+| 93 | 71 | 22 | 51 |

--- a/docs/tofuscan/cis-gke-v1.8.0.md
+++ b/docs/tofuscan/cis-gke-v1.8.0.md
@@ -187,8 +187,8 @@ authentication, and cluster-level settings.
 
 | Control | Title | Type | Covered | Description |
 | --------- | ------- | ------ | --------- | ------------- |
-| 5.9.1 | Enable Customer-Managed Encryption Keys (CMEK) for GKE Persistent Disks | Manual | | Encrypting GKE Persistent Disk volumes with CMEK gives organizations control over the encryption key lifecycle, enabling independent key revocation. |
-| 5.9.2 | Enable Customer-Managed Encryption Keys (CMEK) for Boot Disks | Automated | | Encrypting GKE node boot disks with CMEK ensures node OS data is encrypted with customer-controlled keys, not just Google-managed defaults. |
+| 5.9.1 | Enable Customer-Managed Encryption Keys (CMEK) for GKE Persistent Disks | Manual | ✅ | Encrypting GKE Persistent Disk volumes with CMEK gives organizations control over the encryption key lifecycle, enabling independent key revocation. |
+| 5.9.2 | Enable Customer-Managed Encryption Keys (CMEK) for Boot Disks | Automated | ✅ | Encrypting GKE node boot disks with CMEK ensures node OS data is encrypted with customer-controlled keys, not just Google-managed defaults. |
 
 ### 5.10 Other Cluster Configurations
 
@@ -196,7 +196,7 @@ authentication, and cluster-level settings.
 | --------- | ------- | ------ | --------- | ------------- |
 | 5.10.1 | Ensure Kubernetes Web UI is Disabled | Automated | ✅ | The Kubernetes Dashboard provides a broad cluster management interface. It should be disabled in GKE as it is an additional attack vector and GCP Console provides equivalent functionality. |
 | 5.10.2 | Ensure that Alpha clusters are not used for production workloads | Automated | ✅ | Alpha clusters enable experimental Kubernetes features but receive no SLA, security updates, or support guarantees. They must not be used for production workloads. |
-| 5.10.3 | Consider GKE Sandbox for running untrusted workloads | Automated | | GKE Sandbox uses gVisor to provide an additional layer of isolation between the host kernel and containerized workloads, suitable for running untrusted or multi-tenant code. |
+| 5.10.3 | Consider GKE Sandbox for running untrusted workloads | Automated | ✅ | GKE Sandbox uses gVisor to provide an additional layer of isolation between the host kernel and containerized workloads, suitable for running untrusted or multi-tenant code. |
 | 5.10.4 | Enable Security Posture | Manual | | GKE Security Posture provides continuous assessment of cluster configuration and workload security, surfacing actionable findings aligned with CIS and other benchmarks. |
 
 ---
@@ -205,4 +205,4 @@ authentication, and cluster-level settings.
 
 | Total Controls | Automated | Manual | Implemented |
 | ---------------- | ----------- | -------- | ------------- |
-| 58 | 43 | 15 | 20 |
+| 58 | 43 | 15 | 23 |

--- a/internal/tofuscan/engine/engine_test.go
+++ b/internal/tofuscan/engine/engine_test.go
@@ -101,6 +101,7 @@ func TestFailFixtureViolations(t *testing.T) {
 		"gcp/cis/8.1",
 		"gke/cis/5.9.1",
 		"gke/cis/5.9.2",
+		"gke/cis/5.9.2",
 		"gke/cis/5.10.2",
 		"gke/cis/5.10.3",
 		"gke/cis/5.2.1",

--- a/internal/tofuscan/engine/engine_test.go
+++ b/internal/tofuscan/engine/engine_test.go
@@ -30,6 +30,7 @@ func TestFailFixtureViolations(t *testing.T) {
 	// gke/cis/5.7.1 fires twice (logging + monitoring are separate deny rules).
 	// gcp/cis/5.1 fires twice (iam_member + iam_binding resources).
 	expected := []string{
+		"gcp/cis/1.5",
 		"gcp/cis/1.11",
 		"gcp/cis/1.6",
 		"gcp/cis/1.7",
@@ -85,6 +86,8 @@ func TestFailFixtureViolations(t *testing.T) {
 		"gcp/cis/6.2.8",
 		"gcp/cis/6.3.1",
 		"gcp/cis/6.3.2",
+		"gcp/cis/6.3.3",
+		"gcp/cis/6.3.4",
 		"gcp/cis/6.3.5",
 		"gcp/cis/6.3.6",
 		"gcp/cis/6.3.7",
@@ -95,7 +98,11 @@ func TestFailFixtureViolations(t *testing.T) {
 		"gcp/cis/7.1",
 		"gcp/cis/7.2",
 		"gcp/cis/7.3",
+		"gcp/cis/8.1",
+		"gke/cis/5.9.1",
+		"gke/cis/5.9.2",
 		"gke/cis/5.10.2",
+		"gke/cis/5.10.3",
 		"gke/cis/5.2.1",
 		"gke/cis/5.3.1",
 		"gke/cis/5.4.1",

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.3.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.3.rego
@@ -1,0 +1,29 @@
+package tofuscan
+
+import data.tofuscan.lib
+import rego.v1
+
+_desc_6_3_3 := concat("", [
+	"Setting user connections to a non-zero value limits the number of simultaneous ",
+	"connections allowed per login, which can be exploited to cause a denial of service. ",
+	"The flag should be absent or set to 0 (unlimited) to avoid connection-based DoS risks.",
+])
+
+deny contains violation if {
+	some name, resources in input.resource.google_sql_database_instance
+	some resource in resources
+	lib.is_sqlserver(resource)
+	some settings in resource.settings
+	some flag in object.get(settings, "database_flags", [])
+	flag.name == "user connections"
+	flag.value != "0"
+	violation := {
+		"resource": concat(".", ["google_sql_database_instance", name]),
+		"rule_id": "gcp/cis/6.3.3",
+		"cis_control": "6.3.3",
+		"profile_level": "Level 1",
+		"severity": "Medium",
+		"title": "Ensure user Connections Database Flag for Cloud SQL SQL Server Instance Is Set to a Non-limiting Value",
+		"description": _desc_6_3_3,
+	}
+}

--- a/internal/tofuscan/policies/gcp/cloud_sql/6.3.4.rego
+++ b/internal/tofuscan/policies/gcp/cloud_sql/6.3.4.rego
@@ -1,0 +1,28 @@
+package tofuscan
+
+import data.tofuscan.lib
+import rego.v1
+
+_desc_6_3_4 := concat("", [
+	"The user options flag sets global default query-processing options for all user ",
+	"sessions, which can override individual session settings and create unpredictable ",
+	"behavior. It should not be configured.",
+])
+
+deny contains violation if {
+	some name, resources in input.resource.google_sql_database_instance
+	some resource in resources
+	lib.is_sqlserver(resource)
+	some settings in resource.settings
+	some flag in object.get(settings, "database_flags", [])
+	flag.name == "user options"
+	violation := {
+		"resource": concat(".", ["google_sql_database_instance", name]),
+		"rule_id": "gcp/cis/6.3.4",
+		"cis_control": "6.3.4",
+		"profile_level": "Level 1",
+		"severity": "Medium",
+		"title": "Ensure user options Database Flag for Cloud SQL SQL Server Instance Is Not Configured",
+		"description": _desc_6_3_4,
+	}
+}

--- a/internal/tofuscan/policies/gcp/dataproc/8.1.rego
+++ b/internal/tofuscan/policies/gcp/dataproc/8.1.rego
@@ -1,0 +1,28 @@
+package tofuscan
+
+import rego.v1
+
+_desc_8_1 := concat("", [
+	"Encrypting Dataproc cluster data with a Customer-Managed Encryption Key (CMEK) ",
+	"gives the organization control over the key lifecycle, enabling independent key ",
+	"revocation and rotation without relying on Google-managed defaults.",
+])
+
+deny contains violation if {
+	some name, resources in input.resource.google_dataproc_cluster
+	some resource in resources
+	cc_arr := object.get(resource, "cluster_config", [{}])
+	some cc in cc_arr
+	enc_arr := object.get(cc, "encryption_config", [{}])
+	some enc in enc_arr
+	object.get(enc, "kms_key_name", "") == ""
+	violation := {
+		"resource": concat(".", ["google_dataproc_cluster", name]),
+		"rule_id": "gcp/cis/8.1",
+		"cis_control": "8.1",
+		"profile_level": "Level 2",
+		"severity": "Medium",
+		"title": "Ensure That Dataproc Cluster Is Encrypted Using Customer-Managed Encryption Key",
+		"description": _desc_8_1,
+	}
+}

--- a/internal/tofuscan/policies/gcp/iam/1.5.rego
+++ b/internal/tofuscan/policies/gcp/iam/1.5.rego
@@ -1,0 +1,24 @@
+package tofuscan
+
+import rego.v1
+
+_desc_1_5 := concat("", [
+	"User-managed service account keys are long-lived credentials that are difficult to ",
+	"rotate, audit, and revoke. Only GCP-managed keys should be used; any creation of a ",
+	"user-managed key via google_iam_service_account_key is a violation of this control.",
+])
+
+deny contains violation if {
+	some name, resources in input.resource.google_iam_service_account_key
+	some resource in resources
+	object.get(resource, "key_type", "USER_MANAGED") != "GOOGLE_MANAGED"
+	violation := {
+		"resource": concat(".", ["google_iam_service_account_key", name]),
+		"rule_id": "gcp/cis/1.5",
+		"cis_control": "1.5",
+		"profile_level": "Level 1",
+		"severity": "High",
+		"title": "Ensure That There Are Only GCP-Managed Service Account Keys for Each Service Account",
+		"description": _desc_1_5,
+	}
+}

--- a/internal/tofuscan/policies/gke/kms/5.9.1.rego
+++ b/internal/tofuscan/policies/gke/kms/5.9.1.rego
@@ -1,0 +1,26 @@
+package tofuscan
+
+import rego.v1
+
+_desc_5_9_1 := concat("", [
+	"Encrypting the Kubernetes Secrets backend (etcd) with a Customer-Managed Encryption ",
+	"Key (CMEK) gives the organization independent control over the key lifecycle, enabling ",
+	"key revocation and rotation without relying on Google-managed defaults.",
+])
+
+deny contains violation if {
+	some name, resources in input.resource.google_container_cluster
+	some resource in resources
+	enc_arr := object.get(resource, "database_encryption", [{}])
+	some enc in enc_arr
+	object.get(enc, "key_name", "") == ""
+	violation := {
+		"resource": concat(".", ["google_container_cluster", name]),
+		"rule_id": "gke/cis/5.9.1",
+		"cis_control": "5.9.1",
+		"profile_level": "Level 2",
+		"severity": "Medium",
+		"title": "Enable Customer-Managed Encryption Keys (CMEK) for GKE Persistent Disks",
+		"description": _desc_5_9_1,
+	}
+}

--- a/internal/tofuscan/policies/gke/kms/5.9.2.rego
+++ b/internal/tofuscan/policies/gke/kms/5.9.2.rego
@@ -1,0 +1,25 @@
+package tofuscan
+
+import rego.v1
+
+_desc_5_9_2 := concat("", [
+	"Encrypting GKE node boot disks with a Customer-Managed Encryption Key (CMEK) ensures ",
+	"that node OS data is encrypted with customer-controlled keys, providing independent ",
+	"key revocation beyond Google-managed default encryption.",
+])
+
+deny contains violation if {
+	some name, resources in input.resource.google_container_node_pool
+	some resource in resources
+	some nc in object.get(resource, "node_config", [{}])
+	object.get(nc, "boot_disk_kms_key", "") == ""
+	violation := {
+		"resource": concat(".", ["google_container_node_pool", name]),
+		"rule_id": "gke/cis/5.9.2",
+		"cis_control": "5.9.2",
+		"profile_level": "Level 2",
+		"severity": "Medium",
+		"title": "Enable Customer-Managed Encryption Keys (CMEK) for Boot Disks",
+		"description": _desc_5_9_2,
+	}
+}

--- a/internal/tofuscan/policies/gke/kms/5.9.2.rego
+++ b/internal/tofuscan/policies/gke/kms/5.9.2.rego
@@ -23,3 +23,19 @@ deny contains violation if {
 		"description": _desc_5_9_2,
 	}
 }
+
+deny contains violation if {
+	some name, resources in input.resource.google_container_cluster
+	some resource in resources
+	some nc in object.get(resource, "node_config", [])
+	object.get(nc, "boot_disk_kms_key", "") == ""
+	violation := {
+		"resource": concat(".", ["google_container_cluster", name]),
+		"rule_id": "gke/cis/5.9.2",
+		"cis_control": "5.9.2",
+		"profile_level": "Level 2",
+		"severity": "Medium",
+		"title": "Enable Customer-Managed Encryption Keys (CMEK) for Boot Disks",
+		"description": _desc_5_9_2,
+	}
+}

--- a/internal/tofuscan/policies/gke/other/5.10.3.rego
+++ b/internal/tofuscan/policies/gke/other/5.10.3.rego
@@ -1,0 +1,26 @@
+package tofuscan
+
+import rego.v1
+
+_desc_5_10_3 := concat("", [
+	"GKE Sandbox uses gVisor to provide an additional layer of isolation between the host ",
+	"kernel and containerized workloads. Node pools running untrusted or multi-tenant code ",
+	"should enable gVisor to reduce the impact of container escape vulnerabilities.",
+])
+
+deny contains violation if {
+	some name, resources in input.resource.google_container_node_pool
+	some resource in resources
+	some nc in object.get(resource, "node_config", [{}])
+	some sc in object.get(nc, "sandbox_config", [{}])
+	upper(object.get(sc, "sandbox_type", "")) != "GVISOR"
+	violation := {
+		"resource": concat(".", ["google_container_node_pool", name]),
+		"rule_id": "gke/cis/5.10.3",
+		"cis_control": "5.10.3",
+		"profile_level": "Level 2",
+		"severity": "Medium",
+		"title": "Consider GKE Sandbox for Running Untrusted Workloads",
+		"description": _desc_5_10_3,
+	}
+}

--- a/test/tofuscan/fixtures/fail/main.tofu
+++ b/test/tofuscan/fixtures/fail/main.tofu
@@ -251,6 +251,10 @@ resource "google_container_cluster" "bad_cluster" {
 
   addons_config {
   }
+
+  # GKE CIS 5.9.2 — node_config present but no boot_disk_kms_key
+  node_config {
+  }
 }
 
 # GKE CIS 5.2.1 — service_account = "default" (should use dedicated SA)

--- a/test/tofuscan/fixtures/fail/main.tofu
+++ b/test/tofuscan/fixtures/fail/main.tofu
@@ -346,6 +346,8 @@ resource "google_sql_user" "bad_root_user" {
 
 # GCP CIS 6.3.1 — SQL Server external scripts enabled flag absent (defaults to on)
 # GCP CIS 6.3.2 — SQL Server cross db ownership chaining flag absent (defaults to on)
+# GCP CIS 6.3.3 — user connections flag absent (will be caught only when set to non-zero)
+# GCP CIS 6.3.4 — user options flag absent (no violation; absence is the passing state)
 # GCP CIS 6.3.5 — SQL Server remote access flag absent (defaults to on)
 # GCP CIS 6.3.6 — SQL Server trace flag 3625 absent (error messages not masked)
 # GCP CIS 6.3.7 — SQL Server contained database authentication flag absent (defaults to on)
@@ -365,6 +367,67 @@ resource "google_sql_database_instance" "bad_sqlserver" {
       enabled = true
     }
   }
+}
+
+# GCP CIS 6.3.3 — user connections flag set to a non-zero value (should be 0 or absent)
+# GCP CIS 6.3.4 — user options flag present (should be absent)
+resource "google_sql_database_instance" "bad_sqlserver_flags" {
+  name             = "bad-sqlserver-flags"
+  database_version = "SQLSERVER_2019_STANDARD"
+
+  settings {
+    tier = "db-custom-1-3840"
+
+    backup_configuration {
+      enabled = true
+    }
+
+    database_flags {
+      name  = "3625"
+      value = "on"
+    }
+
+    database_flags {
+      name  = "contained database authentication"
+      value = "off"
+    }
+
+    database_flags {
+      name  = "cross db ownership chaining"
+      value = "off"
+    }
+
+    database_flags {
+      name  = "external scripts enabled"
+      value = "off"
+    }
+
+    database_flags {
+      name  = "remote access"
+      value = "off"
+    }
+
+    database_flags {
+      name  = "user connections"
+      value = "100"
+    }
+
+    database_flags {
+      name  = "user options"
+      value = "1"
+    }
+
+    ip_configuration {
+      ipv4_enabled = false
+      ssl_mode     = "ENCRYPTED_ONLY"
+    }
+  }
+}
+
+# GCP CIS 8.1 — Dataproc cluster without customer-managed encryption key
+resource "google_dataproc_cluster" "bad_dataproc" {
+  name   = "bad-dataproc"
+  region = "us-central1"
 }
 
 # GCP CIS 7.2 — BigQuery table has no customer-managed encryption key

--- a/test/tofuscan/fixtures/pass/main.tofu
+++ b/test/tofuscan/fixtures/pass/main.tofu
@@ -326,7 +326,12 @@ resource "google_container_node_pool" "good_pool" {
   }
 
   node_config {
-    service_account = "my-gke-sa@my-project.iam.gserviceaccount.com"
+    boot_disk_kms_key = "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key"
+    service_account   = "my-gke-sa@my-project.iam.gserviceaccount.com"
+
+    sandbox_config {
+      sandbox_type = "GVISOR"
+    }
 
     shielded_instance_config {
       enable_integrity_monitoring = true
@@ -611,6 +616,18 @@ resource "google_monitoring_alert_policy" "sql_instance_changes_alert" {
       comparison = "COMPARISON_GT"
       duration   = "0s"
       filter     = "metric.type=\"logging.googleapis.com/user/sql_instance_changes\" resource.type=\"global\""
+    }
+  }
+}
+
+# GCP CIS 8.1 — Dataproc cluster with customer-managed encryption key
+resource "google_dataproc_cluster" "good_dataproc" {
+  name   = "good-dataproc"
+  region = "us-central1"
+
+  cluster_config {
+    encryption_config {
+      kms_key_name = "projects/my-project/locations/global/keyRings/my-ring/cryptoKeys/my-key"
     }
   }
 }


### PR DESCRIPTION
## Summary

Implements 7 new tofuscan Rego policies addressing GitHub issues #41–#47.

## New Policies

### GCP CIS v5.0.0
- **1.5** — No user-managed service account keys (`google_iam_service_account_key`)
- **6.3.3** — SQL Server `user connections` flag must be set to `0` (unlimited)
- **6.3.4** — SQL Server `user options` flag must not be set
- **8.1** — Dataproc clusters must use CMEK (`cluster_config.encryption_config.kms_key_name`)

### GKE CIS v1.8.0
- **5.9.1** — GKE cluster database encryption key name must be set
- **5.9.2** — GKE node pool boot disk KMS key must be set
- **5.10.3** — GKE node pool must enable gVisor sandbox

## Changes
- 7 new Rego policy files under `internal/tofuscan/policies/`
- New `gcp/dataproc/` policy directory
- Updated fail/pass fixtures with new test resources
- Updated engine test with 7 new expected violation rule IDs
- Updated CIS coverage docs (GCP: 47→51 implemented, GKE: 20→23 implemented)

Closes #41
Closes #42
Closes #43
Closes #44
Closes #45
Closes #46
Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 7 compliance checks for GCP/GKE covering service account key types, Cloud SQL flags, Dataproc CMEK, GKE persistent/boot disk CMEK, and sandbox configuration.

* **Documentation**
  * Updated CIS GCP v5.0.0 and CIS GKE v1.8.0 docs to mark these controls implemented (coverage: GCP 47→51, GKE 20→23).

* **Tests**
  * Added and updated test fixtures and expectations to cover the new checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->