### PR TITLE
Resolve locals with HCL functions and expand dynamic blocks

### DIFF
--- a/internal/tofuscan/engine/engine.go
+++ b/internal/tofuscan/engine/engine.go
@@ -296,13 +296,19 @@ func normalizeConfig(file string, config interface{}, dirSymbols map[string]*sym
 }
 
 // expandDynamicBlocks recursively expands HCL dynamic blocks where for_each
-// has been resolved to a concrete list. For each item in for_each it
-// materialises the content template by substituting "<blockName>.value.<attr>"
+// has been resolved to a concrete list or map. For each item in for_each it
+// materialises the content template by substituting "<iterName>.value.<attr>"
 // references with the corresponding attribute from that item, then promotes the
 // result to a top-level key at the same map level:
 //
 //	"dynamic": { "X": [{"for_each": [...], "content": [...]}] }
 //	→  "X": [<materialised content per item>, ...]
+//
+// The iterator name defaults to the block label but may be overridden via the
+// optional "iterator" attribute. When for_each is a map, its values are used as
+// items (map keys are not accessible in content templates at this analysis
+// level). Dynamic block entries whose for_each remains unresolved are preserved
+// in the output rather than silently dropped.
 //
 // This lets Rego policies that inspect resource attributes (e.g. database_flags)
 // find the expanded values rather than the raw dynamic block structure.
@@ -325,40 +331,64 @@ func expandDynamicBlocks(value interface{}) interface{} {
 			}
 		}
 
-		// Second pass: expand dynamic blocks into their block-name keys.
+		// Second pass: expand dynamic blocks into their block-name keys,
+		// collecting any that cannot be expanded back into result["dynamic"].
 		if dynVal, ok := typed["dynamic"]; ok {
 			dynamicMap, ok := dynVal.(map[string]interface{})
 			if !ok {
 				result["dynamic"] = dynVal
 				return result
 			}
+			remaining := make(map[string]interface{})
 			for blockName, blockEntries := range dynamicMap {
 				entries, ok := blockEntries.([]interface{})
 				if !ok {
+					remaining[blockName] = blockEntries
 					continue
 				}
+				var unexpanded []interface{}
 				for _, entry := range entries {
 					entryMap, ok := entry.(map[string]interface{})
 					if !ok {
+						unexpanded = append(unexpanded, entry)
 						continue
 					}
-					forEachVal, ok := entryMap["for_each"]
-					if !ok {
+					forEachVal, hasFE := entryMap["for_each"]
+					if !hasFE {
+						unexpanded = append(unexpanded, entry)
 						continue
 					}
-					items, ok := forEachVal.([]interface{})
-					if !ok {
+
+					// Normalise for_each to a []interface{} of items.
+					// For maps, the values become the iteration items; keys
+					// are not surfaced in content templates at this level.
+					var items []interface{}
+					switch v := forEachVal.(type) {
+					case []interface{}:
+						items = v
+					case map[string]interface{}:
+						for _, val := range v {
+							items = append(items, val)
+						}
+					default:
+						// Unresolved or unsupported type — preserve the entry.
+						unexpanded = append(unexpanded, entry)
 						continue
 					}
+
+					// Respect the optional "iterator" attribute that overrides
+					// the default iteration variable name (the block label).
+					iterName := blockName
+					if iter, ok := entryMap["iterator"].(string); ok && iter != "" {
+						iterName = iter
+					}
+
 					contentEntries, _ := entryMap["content"].([]interface{})
 					existing, _ := result[blockName].([]interface{})
 					for _, item := range items {
 						if len(contentEntries) > 0 {
-							// Materialise each content entry by substituting
-							// "<blockName>.value.<attr>" references with values
-							// from the current for_each item.
 							for _, ce := range contentEntries {
-								materialised := applyEachValue(ce, blockName, item)
+								materialised := applyEachValue(ce, iterName, item)
 								existing = append(existing, expandDynamicBlocks(materialised))
 							}
 						} else {
@@ -367,6 +397,12 @@ func expandDynamicBlocks(value interface{}) interface{} {
 					}
 					result[blockName] = existing
 				}
+				if len(unexpanded) > 0 {
+					remaining[blockName] = unexpanded
+				}
+			}
+			if len(remaining) > 0 {
+				result["dynamic"] = remaining
 			}
 		}
 

--- a/internal/tofuscan/engine/engine.go
+++ b/internal/tofuscan/engine/engine.go
@@ -296,15 +296,14 @@ func normalizeConfig(file string, config interface{}, dirSymbols map[string]*sym
 }
 
 // expandDynamicBlocks recursively expands HCL dynamic blocks where for_each
-// has been resolved to a concrete list. It replaces
+// has been resolved to a concrete list. For each item in for_each it
+// materialises the content template by substituting "<blockName>.value.<attr>"
+// references with the corresponding attribute from that item, then promotes the
+// result to a top-level key at the same map level:
 //
 //	"dynamic": { "X": [{"for_each": [...], "content": [...]}] }
+//	→  "X": [<materialised content per item>, ...]
 //
-// with
-//
-//	"X": [...]
-//
-// at the same map level, using the for_each items directly as block entries.
 // This lets Rego policies that inspect resource attributes (e.g. database_flags)
 // find the expanded values rather than the raw dynamic block structure.
 func expandDynamicBlocks(value interface{}) interface{} {
@@ -343,22 +342,74 @@ func expandDynamicBlocks(value interface{}) interface{} {
 					if !ok {
 						continue
 					}
-					forEach, ok := entryMap["for_each"]
+					forEachVal, ok := entryMap["for_each"]
 					if !ok {
 						continue
 					}
-					items, ok := forEach.([]interface{})
+					items, ok := forEachVal.([]interface{})
 					if !ok {
 						continue
 					}
+					contentEntries, _ := entryMap["content"].([]interface{})
 					existing, _ := result[blockName].([]interface{})
-					result[blockName] = append(existing, items...)
+					for _, item := range items {
+						if len(contentEntries) > 0 {
+							// Materialise each content entry by substituting
+							// "<blockName>.value.<attr>" references with values
+							// from the current for_each item.
+							for _, ce := range contentEntries {
+								materialised := applyEachValue(ce, blockName, item)
+								existing = append(existing, expandDynamicBlocks(materialised))
+							}
+						} else {
+							existing = append(existing, expandDynamicBlocks(item))
+						}
+					}
+					result[blockName] = existing
 				}
 			}
 		}
 
 		return result
 
+	default:
+		return value
+	}
+}
+
+// applyEachValue recursively replaces "${<blockName>.value.<attr>}" reference
+// strings in a content template with the corresponding attribute value from
+// the current for_each item. This mimics OpenTofu's dynamic block iteration
+// variable (<blockName>.value) at the level of static policy analysis.
+func applyEachValue(value interface{}, blockName string, item interface{}) interface{} {
+	prefix := blockName + ".value."
+	switch typed := value.(type) {
+	case string:
+		if !strings.HasPrefix(typed, "${") || !strings.HasSuffix(typed, "}") {
+			return typed
+		}
+		expr := strings.TrimSuffix(strings.TrimPrefix(typed, "${"), "}")
+		if strings.HasPrefix(expr, prefix) {
+			attr := strings.TrimPrefix(expr, prefix)
+			if itemMap, ok := item.(map[string]interface{}); ok {
+				if v, exists := itemMap[attr]; exists {
+					return v
+				}
+			}
+		}
+		return typed
+	case map[string]interface{}:
+		resolved := make(map[string]interface{}, len(typed))
+		for k, v := range typed {
+			resolved[k] = applyEachValue(v, blockName, item)
+		}
+		return resolved
+	case []interface{}:
+		resolved := make([]interface{}, len(typed))
+		for i, v := range typed {
+			resolved[i] = applyEachValue(v, blockName, item)
+		}
+		return resolved
 	default:
 		return value
 	}

--- a/internal/tofuscan/engine/engine.go
+++ b/internal/tofuscan/engine/engine.go
@@ -291,7 +291,77 @@ func normalizeConfig(file string, config interface{}, dirSymbols map[string]*sym
 		return config
 	}
 
-	return resolveReferences(config, symbols)
+	resolved := resolveReferences(config, symbols)
+	return expandDynamicBlocks(resolved)
+}
+
+// expandDynamicBlocks recursively expands HCL dynamic blocks where for_each
+// has been resolved to a concrete list. It replaces
+//
+//	"dynamic": { "X": [{"for_each": [...], "content": [...]}] }
+//
+// with
+//
+//	"X": [...]
+//
+// at the same map level, using the for_each items directly as block entries.
+// This lets Rego policies that inspect resource attributes (e.g. database_flags)
+// find the expanded values rather than the raw dynamic block structure.
+func expandDynamicBlocks(value interface{}) interface{} {
+	switch typed := value.(type) {
+	case []interface{}:
+		result := make([]interface{}, 0, len(typed))
+		for _, item := range typed {
+			result = append(result, expandDynamicBlocks(item))
+		}
+		return result
+
+	case map[string]interface{}:
+		result := make(map[string]interface{}, len(typed))
+
+		// First pass: copy all non-dynamic keys (recursively expanded).
+		for key, item := range typed {
+			if key != "dynamic" {
+				result[key] = expandDynamicBlocks(item)
+			}
+		}
+
+		// Second pass: expand dynamic blocks into their block-name keys.
+		if dynVal, ok := typed["dynamic"]; ok {
+			dynamicMap, ok := dynVal.(map[string]interface{})
+			if !ok {
+				result["dynamic"] = dynVal
+				return result
+			}
+			for blockName, blockEntries := range dynamicMap {
+				entries, ok := blockEntries.([]interface{})
+				if !ok {
+					continue
+				}
+				for _, entry := range entries {
+					entryMap, ok := entry.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					forEach, ok := entryMap["for_each"]
+					if !ok {
+						continue
+					}
+					items, ok := forEach.([]interface{})
+					if !ok {
+						continue
+					}
+					existing, _ := result[blockName].([]interface{})
+					result[blockName] = append(existing, items...)
+				}
+			}
+		}
+
+		return result
+
+	default:
+		return value
+	}
 }
 
 // buildDirSymbolTables groups the given files by directory and builds one
@@ -396,6 +466,7 @@ func resolveLocals(pending map[string]*hclsyntax.Attribute, variables map[string
 	for len(pending) > 0 {
 		resolvedAny := false
 		ctx := &hcl.EvalContext{
+			Functions: hclFunctions(),
 			Variables: map[string]cty.Value{
 				"local": ctyObject(locals),
 				"var":   ctyObject(variables),

--- a/internal/tofuscan/engine/engine_test.go
+++ b/internal/tofuscan/engine/engine_test.go
@@ -533,6 +533,60 @@ variable "postgres_database_flags" {
 	}
 }
 
+// TestExpandDynamicBlocksMaterialisesContent verifies that expandDynamicBlocks
+// resolves "<blockName>.value.<attr>" references in the content template rather
+// than using the for_each items verbatim. This covers cases where content
+// renames or restructures the iterator value.
+func TestExpandDynamicBlocksMaterialisesContent(t *testing.T) {
+	input := map[string]interface{}{
+		"dynamic": map[string]interface{}{
+			"tag": []interface{}{
+				map[string]interface{}{
+					"for_each": []interface{}{
+						map[string]interface{}{"k": "env", "v": "prod"},
+						map[string]interface{}{"k": "team", "v": "platform"},
+					},
+					"content": []interface{}{
+						map[string]interface{}{
+							"key":   "${tag.value.k}",
+							"value": "${tag.value.v}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := expandDynamicBlocks(input).(map[string]interface{})
+	tags, ok := got["tag"].([]interface{})
+	if !ok {
+		t.Fatalf("expected tag to be []interface{}, got %T", got["tag"])
+	}
+	if len(tags) != 2 {
+		t.Fatalf("expected 2 tag entries, got %d", len(tags))
+	}
+
+	want := []map[string]interface{}{
+		{"key": "env", "value": "prod"},
+		{"key": "team", "value": "platform"},
+	}
+	for i, entry := range tags {
+		m, ok := entry.(map[string]interface{})
+		if !ok {
+			t.Fatalf("tag[%d]: expected map, got %T", i, entry)
+		}
+		for k, wantV := range want[i] {
+			if got := m[k]; got != wantV {
+				t.Errorf("tag[%d][%q]: got %v, want %v", i, k, got, wantV)
+			}
+		}
+	}
+
+	if _, hasDynamic := got["dynamic"]; hasDynamic {
+		t.Error("dynamic key should have been removed after expansion")
+	}
+}
+
 func TestNormalizeConfigResolvesReferencesAcrossFiles(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/internal/tofuscan/engine/engine_test.go
+++ b/internal/tofuscan/engine/engine_test.go
@@ -587,6 +587,116 @@ func TestExpandDynamicBlocksMaterialisesContent(t *testing.T) {
 	}
 }
 
+// TestExpandDynamicBlocksMapForEach verifies that map for_each values are
+// normalised to a slice of their values for content materialisation.
+func TestExpandDynamicBlocksMapForEach(t *testing.T) {
+	input := map[string]interface{}{
+		"dynamic": map[string]interface{}{
+			"setting": []interface{}{
+				map[string]interface{}{
+					"for_each": map[string]interface{}{
+						"a": map[string]interface{}{"name": "key-a", "value": "val-a"},
+						"b": map[string]interface{}{"name": "key-b", "value": "val-b"},
+					},
+					"content": []interface{}{
+						map[string]interface{}{
+							"name":  "${setting.value.name}",
+							"value": "${setting.value.value}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := expandDynamicBlocks(input).(map[string]interface{})
+	settings, ok := got["setting"].([]interface{})
+	if !ok {
+		t.Fatalf("expected setting to be []interface{}, got %T", got["setting"])
+	}
+	if len(settings) != 2 {
+		t.Fatalf("expected 2 setting entries, got %d", len(settings))
+	}
+	// Collect names to verify both items expanded regardless of map iteration order.
+	names := make(map[string]string)
+	for _, s := range settings {
+		m := s.(map[string]interface{})
+		names[m["name"].(string)] = m["value"].(string)
+	}
+	if names["key-a"] != "val-a" {
+		t.Errorf("key-a: got %q, want %q", names["key-a"], "val-a")
+	}
+	if names["key-b"] != "val-b" {
+		t.Errorf("key-b: got %q, want %q", names["key-b"], "val-b")
+	}
+}
+
+// TestExpandDynamicBlocksCustomIterator verifies that an explicit "iterator"
+// attribute overrides the default iteration variable name (the block label).
+func TestExpandDynamicBlocksCustomIterator(t *testing.T) {
+	input := map[string]interface{}{
+		"dynamic": map[string]interface{}{
+			"database_flags": []interface{}{
+				map[string]interface{}{
+					"iterator": "flag",
+					"for_each": []interface{}{
+						map[string]interface{}{"name": "log_connections", "value": "on"},
+					},
+					"content": []interface{}{
+						map[string]interface{}{
+							"name":  "${flag.value.name}",
+							"value": "${flag.value.value}",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got := expandDynamicBlocks(input).(map[string]interface{})
+	flags, ok := got["database_flags"].([]interface{})
+	if !ok {
+		t.Fatalf("expected database_flags to be []interface{}, got %T", got["database_flags"])
+	}
+	if len(flags) != 1 {
+		t.Fatalf("expected 1 flag, got %d", len(flags))
+	}
+	m := flags[0].(map[string]interface{})
+	if m["name"] != "log_connections" {
+		t.Errorf("name: got %v, want %q", m["name"], "log_connections")
+	}
+	if m["value"] != "on" {
+		t.Errorf("value: got %v, want %q", m["value"], "on")
+	}
+}
+
+// TestExpandDynamicBlocksUnresolvedPreserved verifies that a dynamic block
+// whose for_each could not be resolved is preserved rather than silently dropped.
+func TestExpandDynamicBlocksUnresolvedPreserved(t *testing.T) {
+	entry := map[string]interface{}{
+		"for_each": "${local.unresolved}",
+		"content":  []interface{}{},
+	}
+	input := map[string]interface{}{
+		"dynamic": map[string]interface{}{
+			"setting": []interface{}{entry},
+		},
+	}
+
+	got := expandDynamicBlocks(input).(map[string]interface{})
+	dynVal, hasDynamic := got["dynamic"]
+	if !hasDynamic {
+		t.Fatal("expected dynamic key to be preserved for unresolved for_each")
+	}
+	dynMap, ok := dynVal.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected dynamic to be map, got %T", dynVal)
+	}
+	if _, ok := dynMap["setting"]; !ok {
+		t.Error("expected unresolved setting block to be preserved under dynamic")
+	}
+}
+
 func TestNormalizeConfigResolvesReferencesAcrossFiles(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/internal/tofuscan/engine/engine_test.go
+++ b/internal/tofuscan/engine/engine_test.go
@@ -451,6 +451,88 @@ resource "google_container_cluster" "primary" {
 	}
 }
 
+// TestDynamicBlockExpansionWithLocalFunctions covers the false-positive pattern
+// seen in the pt-arche-google-cloud-sql module, where database_flags are
+// defined via concat() and startswith() in locals.tofu, then used in a dynamic
+// block in main.tofu. Both the function evaluation and dynamic block expansion
+// must work together to avoid false-positive CIS 6.2.x violations.
+func TestDynamicBlockExpansionWithLocalFunctions(t *testing.T) {
+	tmp := t.TempDir()
+
+	variablesContent := `variable "database_version" {
+  default = "POSTGRES_16"
+  type    = string
+}
+
+variable "postgres_database_flags" {
+  default = []
+  type = list(object({
+    name  = string
+    value = string
+  }))
+}
+`
+
+	localsContent := `locals {
+  postgres_database_flags = concat([
+    {
+      name  = "log_connections"
+      value = "on"
+    },
+    {
+      name  = "log_disconnections"
+      value = "on"
+    },
+  ], var.postgres_database_flags)
+
+  database_flags = startswith(var.database_version, "POSTGRES_") ? local.postgres_database_flags : []
+}
+`
+
+	mainContent := `resource "google_sql_database_instance" "this" {
+  database_version = var.database_version
+
+  settings {
+    dynamic "database_flags" {
+      for_each = local.database_flags
+      content {
+        name  = database_flags.value.name
+        value = database_flags.value.value
+      }
+    }
+
+    tier = "db-n1-standard-1"
+  }
+}
+`
+
+	variablesFile := tmp + "/variables.tofu"
+	localsFile := tmp + "/locals.tofu"
+	mainFile := tmp + "/main.tofu"
+
+	for path, content := range map[string]string{
+		variablesFile: variablesContent,
+		localsFile:    localsContent,
+		mainFile:      mainContent,
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := Run(context.Background(), []string{variablesFile, localsFile, mainFile}, policies.FS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// CIS 6.2.2 (log_connections) and 6.2.3 (log_disconnections) must not fire.
+	for _, v := range result.Violations {
+		if v.RuleID == "gcp/cis/6.2.2" || v.RuleID == "gcp/cis/6.2.3" {
+			t.Errorf("false positive: %s fired on resource with dynamic database_flags via locals", v.RuleID)
+		}
+	}
+}
+
 func TestNormalizeConfigResolvesReferencesAcrossFiles(t *testing.T) {
 	tmp := t.TempDir()
 

--- a/internal/tofuscan/engine/functions.go
+++ b/internal/tofuscan/engine/functions.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
@@ -46,6 +47,8 @@ var endsWithFn = function.New(&function.Spec{
 
 // concatFn implements the OpenTofu concat(lists...) built-in.
 // It concatenates any number of lists or tuples into a single tuple value.
+// Returns an error for any argument that is not a list or tuple type, matching
+// OpenTofu's behaviour.
 // A tuple is used as the return type to accommodate lists with differing
 // element types (e.g. list(object) merged with list(object)).
 var concatFn = function.New(&function.Spec{
@@ -57,9 +60,10 @@ var concatFn = function.New(&function.Spec{
 	Type: function.StaticReturnType(cty.DynamicPseudoType),
 	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
 		var elems []cty.Value
-		for _, arg := range args {
-			if !arg.CanIterateElements() {
-				continue
+		for i, arg := range args {
+			ty := arg.Type()
+			if !ty.IsListType() && !ty.IsTupleType() {
+				return cty.NilVal, fmt.Errorf("argument %d: list or tuple required, got %s", i+1, ty.FriendlyName())
 			}
 			for it := arg.ElementIterator(); it.Next(); {
 				_, v := it.Element()

--- a/internal/tofuscan/engine/functions.go
+++ b/internal/tofuscan/engine/functions.go
@@ -1,0 +1,74 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+// hclFunctions returns the minimal set of HCL/OpenTofu built-in functions
+// needed to evaluate locals that use common string and collection operations.
+// Only functions that appear in real-world module locals are included.
+func hclFunctions() map[string]function.Function {
+	return map[string]function.Function{
+		"concat":     concatFn,
+		"endswith":   endsWithFn,
+		"merge":      stdlib.MergeFunc,
+		"startswith": startsWithFn,
+	}
+}
+
+// startsWithFn implements the OpenTofu startswith(str, prefix) built-in.
+var startsWithFn = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "str", Type: cty.String},
+		{Name: "prefix", Type: cty.String},
+	},
+	Type: function.StaticReturnType(cty.Bool),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		return cty.BoolVal(strings.HasPrefix(args[0].AsString(), args[1].AsString())), nil
+	},
+})
+
+// endsWithFn implements the OpenTofu endswith(str, suffix) built-in.
+var endsWithFn = function.New(&function.Spec{
+	Params: []function.Parameter{
+		{Name: "str", Type: cty.String},
+		{Name: "suffix", Type: cty.String},
+	},
+	Type: function.StaticReturnType(cty.Bool),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		return cty.BoolVal(strings.HasSuffix(args[0].AsString(), args[1].AsString())), nil
+	},
+})
+
+// concatFn implements the OpenTofu concat(lists...) built-in.
+// It concatenates any number of lists or tuples into a single tuple value.
+// A tuple is used as the return type to accommodate lists with differing
+// element types (e.g. list(object) merged with list(object)).
+var concatFn = function.New(&function.Spec{
+	VarParam: &function.Parameter{
+		Name:             "seqs",
+		Type:             cty.DynamicPseudoType,
+		AllowDynamicType: true,
+	},
+	Type: function.StaticReturnType(cty.DynamicPseudoType),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		var elems []cty.Value
+		for _, arg := range args {
+			if !arg.CanIterateElements() {
+				continue
+			}
+			for it := arg.ElementIterator(); it.Next(); {
+				_, v := it.Element()
+				elems = append(elems, v)
+			}
+		}
+		if len(elems) == 0 {
+			return cty.TupleVal([]cty.Value{}), nil
+		}
+		return cty.TupleVal(elems), nil
+	},
+})


### PR DESCRIPTION
## Summary

Fixes false-positive CIS violations on modules that use dynamic blocks driven by locals containing HCL built-in function calls.

### Root causes

**1. Missing HCL functions in eval context**

`resolveLocals` had no functions registered in its `hcl.EvalContext`, so locals using `startswith()`, `endswith()`, `concat()`, or `merge()` silently failed to resolve. In `pt-arche-google-cloud-sql`, `local.database_flags` is built via `concat()` and `startswith()` — it never resolved, leaving the dynamic block reference unresolvable.

**2. Dynamic blocks not expanded**

Even with locals resolved, conftest parses `dynamic "database_flags" { for_each = ... }` as `settings.dynamic.database_flags[0].for_each`, not as `settings.database_flags[]`. The Rego policies check `settings.database_flags`, so they never found the flags and fired false positives.

### Changes

- **`functions.go`** (new) — defines `startswith`, `endswith`, `concat`, and `merge` as HCL function objects registered via `hclFunctions()`
- **`engine.go`** — `resolveLocals` now includes `Functions: hclFunctions()` in the eval context; `normalizeConfig` calls new `expandDynamicBlocks` after reference resolution to promote `dynamic.X[].for_each` items up to `X[]`
- **`engine_test.go`** — new `TestDynamicBlockExpansionWithLocalFunctions` reproducing the exact SQL module pattern (concat + startswith in locals, dynamic database_flags in resource)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced support for HCL-style `dynamic` blocks by fully materializing `content` entries using the active iterator context.
  * Local expression evaluation now supports common functions such as `concat`, `startswith`, `endswith`, and `merge`.
* **Bug Fixes**
  * Reduced false-positive policy violations when `dynamic` content is produced from computed locals using functions.
  * Preserves unexpected or unsupported `dynamic` structures instead of expanding them incorrectly.
* **Tests**
  * Added coverage to verify policy outcomes when `dynamic` blocks rely on locals with function calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->