### PR TITLE
Remove dead code and duplicate logic

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -64,7 +64,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Regal
-        uses: StyraInc/setup-regal@33a142b1189004e0f14bf42b15972c67eecce776  # v1.0.0
+        uses: open-policy-agent/setup-regal@761188c3b435761fa254beca508a44875619648f  # v2.0.0
         with:
           version: v0.40.0
 

--- a/cmd/tofufmt/main.go
+++ b/cmd/tofufmt/main.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"pre-commit-hooks/internal/output"
+	"pre-commit-hooks/internal/testutil"
 	"pre-commit-hooks/internal/tofufmt"
 )
 
@@ -23,7 +24,7 @@ func truncateLine(s string, maxWidth int) string {
 func main() {
 	err := RunTofuFmtCLI(
 		os.Args[1:],
-		tofufmt.CheckOpenTofuInstalled,
+		testutil.CheckOpenTofuInstalled,
 		os.Getwd,
 		tofufmt.RunTofuFmt,
 		tofufmt.FormatFiles,

--- a/cmd/tofutest/main.go
+++ b/cmd/tofutest/main.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 
 	"pre-commit-hooks/internal/output"
+	"pre-commit-hooks/internal/testutil"
 	"pre-commit-hooks/internal/tofutest"
 )
 
 func main() {
 	err := RunTofuTestCLI(
 		parseExtraArgs(os.Args[1:]),
-		tofutest.CheckOpenTofuInstalled,
+		testutil.CheckOpenTofuInstalled,
 		os.Getwd,
 		tofutest.HasTestFiles,
 		tofutest.RunTofuTest,

--- a/cmd/tofuvalidate/main.go
+++ b/cmd/tofuvalidate/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"pre-commit-hooks/internal/output"
+	"pre-commit-hooks/internal/testutil"
 	"pre-commit-hooks/internal/tofuvalidate"
 )
 
@@ -22,7 +23,7 @@ func main() {
 	}
 	err := RunTofuValidateCLI(
 		extraArgs,
-		tofuvalidate.CheckOpenTofuInstalled,
+		testutil.CheckOpenTofuInstalled,
 		os.Getwd,
 		findDirsWithTfFiles,
 		runCmdInDir,

--- a/internal/output/summary.go
+++ b/internal/output/summary.go
@@ -112,32 +112,21 @@ func normalizeBlock(block string) string {
 	return strings.Join(parts, "\n")
 }
 
-// PrintWarningSummary prints warning messages as styled cards,
-// deduplicating equivalent warnings across directories.
-func PrintWarningSummary(warningMessages []TofuMessage) {
-	if len(warningMessages) == 0 {
+// printSummaryCards renders grouped messages as styled cards.
+func printSummaryCards(msgs []TofuMessage, badge, badgeColor, borderColor, titleSuffix string, extractLines func(string) []string) {
+	if len(msgs) == 0 {
 		return
 	}
-
-	groups := groupMessages(warningMessages)
+	groups := groupMessages(msgs)
 	for i, g := range groups {
-		c := NewCard(Yellow)
-		c.Open(Badge("WARNING", BoldYellow), Title("OpenTofu "+g.step))
+		c := NewCard(borderColor)
+		c.Open(Badge(badge, badgeColor), Title("OpenTofu "+g.step+titleSuffix))
 		for _, p := range g.paths {
 			c.Line(fmt.Sprintf("%s %s", File, Colorize(p, Gray)))
 		}
 		c.Blank()
-
-		lines := strings.Split(g.raw, "\n")
-		inWarning := false
-		for _, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if strings.Contains(trimmed, "Warning:") {
-				inWarning = true
-			}
-			if inWarning && trimmed != "" {
-				c.Line(fmt.Sprintf("%s%s%s", Dim, line, Reset))
-			}
+		for _, line := range extractLines(g.raw) {
+			c.Line(fmt.Sprintf("%s%s%s", Dim, line, Reset))
 		}
 		c.Close()
 		if i < len(groups)-1 {
@@ -146,31 +135,39 @@ func PrintWarningSummary(warningMessages []TofuMessage) {
 	}
 }
 
+func warningLines(raw string) []string {
+	var lines []string
+	triggered := false
+	for _, line := range strings.Split(raw, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "Warning:") {
+			triggered = true
+		}
+		if triggered && trimmed != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func errorLines(raw string) []string {
+	var lines []string
+	for _, line := range strings.Split(raw, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+// PrintWarningSummary prints warning messages as styled cards,
+// deduplicating equivalent warnings across directories.
+func PrintWarningSummary(warningMessages []TofuMessage) {
+	printSummaryCards(warningMessages, "WARNING", BoldYellow, Yellow, "", warningLines)
+}
+
 // PrintErrorSummary prints error messages as styled cards,
 // deduplicating equivalent errors across directories.
 func PrintErrorSummary(errorMessages []TofuMessage) {
-	if len(errorMessages) == 0 {
-		return
-	}
-
-	groups := groupMessages(errorMessages)
-	for i, g := range groups {
-		c := NewCard(Red)
-		c.Open(Badge("ERROR", BoldRed), Title("OpenTofu "+g.step+" failed"))
-		for _, p := range g.paths {
-			c.Line(fmt.Sprintf("%s %s", File, Colorize(p, Gray)))
-		}
-		c.Blank()
-
-		lines := strings.Split(g.raw, "\n")
-		for _, line := range lines {
-			if strings.TrimSpace(line) != "" {
-				c.Line(fmt.Sprintf("%s%s%s", Dim, line, Reset))
-			}
-		}
-		c.Close()
-		if i < len(groups)-1 {
-			fmt.Println()
-		}
-	}
+	printSummaryCards(errorMessages, "ERROR", BoldRed, Red, " failed", errorLines)
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -48,11 +48,3 @@ func RestoreWorkingDir(t *testing.T, newDir string) func() {
 		}
 	}
 }
-
-// RunCmd runs a command and returns its combined output and error
-func RunCmd(name string, args ...string) (string, error) {
-	// no-dd-sa:go-security/command-injection - https://github.com/osinfra-io/pt-techne-pre-commit-hooks/issues/8
-	cmd := exec.Command(name, args...)
-	out, err := cmd.CombinedOutput()
-	return string(out), err
-}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -65,13 +65,3 @@ func TestRestoreWorkingDir(t *testing.T) {
 		t.Errorf("Did not restore to original dir. got: %v, want: %v", finalDirEval, origEval)
 	}
 }
-
-func TestRunCmd(t *testing.T) {
-	output, err := RunCmd("echo", "hello world")
-	if err != nil {
-		t.Fatalf("RunCmd failed: %v", err)
-	}
-	if want := "hello world\n"; output != want {
-		t.Errorf("RunCmd output: got %q, want %q", output, want)
-	}
-}

--- a/internal/tofufmt/tofufmt.go
+++ b/internal/tofufmt/tofufmt.go
@@ -2,12 +2,7 @@ package tofufmt
 
 import (
 	"os/exec"
-
-	"pre-commit-hooks/internal/testutil"
 )
-
-// CheckOpenTofuInstalled delegates to shared testutil implementation.
-var CheckOpenTofuInstalled = testutil.CheckOpenTofuInstalled
 
 // RunTofuFmt runs tofu fmt recursively in the given directory with extra args.
 // Returns output and error.

--- a/internal/tofuscan/output/output.go
+++ b/internal/tofuscan/output/output.go
@@ -378,6 +378,21 @@ func truncatePath(path string, maxLen int) string {
 	return path[:headLen] + "…" + tail
 }
 
+// applicableRuleIDs returns the set of rule IDs whose associated resource types
+// overlap with resourceTypes. Caller must have called initRuleMetadata() first.
+func applicableRuleIDs(resourceTypes map[string]struct{}) map[string]struct{} {
+	matched := make(map[string]struct{})
+	for ruleID, ruleTypes := range ruleResourceMap {
+		for rt := range ruleTypes {
+			if _, present := resourceTypes[rt]; present {
+				matched[ruleID] = struct{}{}
+				break
+			}
+		}
+	}
+	return matched
+}
+
 // computePassingRules returns metadata for rules that matched scanned
 // resource types but produced no violations and were not skipped.
 func computePassingRules(violations, skipped []engine.Violation, resourceTypes map[string]struct{}) []*RuleMetadata {
@@ -390,30 +405,20 @@ func computePassingRules(violations, skipped []engine.Violation, resourceTypes m
 		return nil
 	}
 
-	failingOrSkippedRules := make(map[string]struct{})
-	for _, v := range violations {
+	failedRules := make(map[string]struct{})
+	for _, v := range append(violations, skipped...) {
 		if v.RuleID != "" {
-			failingOrSkippedRules[v.RuleID] = struct{}{}
-		}
-	}
-	for _, v := range skipped {
-		if v.RuleID != "" {
-			failingOrSkippedRules[v.RuleID] = struct{}{}
+			failedRules[v.RuleID] = struct{}{}
 		}
 	}
 
 	var passing []*RuleMetadata
-	for ruleID, ruleTypes := range ruleResourceMap {
-		if _, failed := failingOrSkippedRules[ruleID]; failed {
+	for ruleID := range applicableRuleIDs(resourceTypes) {
+		if _, failed := failedRules[ruleID]; failed {
 			continue
 		}
-		for rt := range ruleTypes {
-			if _, present := resourceTypes[rt]; present {
-				if meta, ok := ruleMetadataMap[ruleID]; ok {
-					passing = append(passing, meta)
-				}
-				break
-			}
+		if meta, ok := ruleMetadataMap[ruleID]; ok {
+			passing = append(passing, meta)
 		}
 	}
 
@@ -441,38 +446,21 @@ func computePassedRulesCount(violations, skipped []engine.Violation, resourceTyp
 		return 0, false
 	}
 
-	// Count rules whose target resource types are present in the scanned code.
-	matchingRules := make(map[string]struct{})
-	for ruleID, ruleTypes := range ruleResourceMap {
-		for rt := range ruleTypes {
-			if _, present := resourceTypes[rt]; present {
-				matchingRules[ruleID] = struct{}{}
-				break
-			}
-		}
-	}
-
-	if len(matchingRules) == 0 {
+	matched := applicableRuleIDs(resourceTypes)
+	if len(matched) == 0 {
 		return 0, false
 	}
 
-	failingOrSkippedRules := make(map[string]struct{})
-	for _, v := range violations {
+	failedRules := make(map[string]struct{})
+	for _, v := range append(violations, skipped...) {
 		if v.RuleID != "" {
-			if _, matching := matchingRules[v.RuleID]; matching {
-				failingOrSkippedRules[v.RuleID] = struct{}{}
-			}
-		}
-	}
-	for _, v := range skipped {
-		if v.RuleID != "" {
-			if _, matching := matchingRules[v.RuleID]; matching {
-				failingOrSkippedRules[v.RuleID] = struct{}{}
+			if _, ok := matched[v.RuleID]; ok {
+				failedRules[v.RuleID] = struct{}{}
 			}
 		}
 	}
 
-	passed := len(matchingRules) - len(failingOrSkippedRules)
+	passed := len(matched) - len(failedRules)
 	if passed < 0 {
 		passed = 0
 	}

--- a/internal/tofutest/tofutest.go
+++ b/internal/tofutest/tofutest.go
@@ -5,12 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-
-	"pre-commit-hooks/internal/testutil"
 )
-
-// CheckOpenTofuInstalled delegates to shared testutil implementation.
-var CheckOpenTofuInstalled = testutil.CheckOpenTofuInstalled
 
 // HasTestFiles recursively searches for .tftest.hcl files in the given directory.
 // Returns true if any test files are found, false otherwise.

--- a/internal/tofuvalidate/tofuvalidate.go
+++ b/internal/tofuvalidate/tofuvalidate.go
@@ -2,12 +2,7 @@ package tofuvalidate
 
 import (
 	"os/exec"
-
-	"pre-commit-hooks/internal/testutil"
 )
-
-// CheckOpenTofuInstalled delegates to shared testutil implementation.
-var CheckOpenTofuInstalled = testutil.CheckOpenTofuInstalled
 
 // RunTofuValidate runs tofu validate in the given directory with extra args.
 // Returns output and error.


### PR DESCRIPTION
## What changed

- **Deleted `testutil.RunCmd`** — exported function with no callers outside its own test; test deleted too
- **Removed `CheckOpenTofuInstalled` alias vars** from `tofufmt`, `tofutest`, `tofuvalidate` — each was a one-line re-export of `testutil.CheckOpenTofuInstalled` never mutated by any test; `main.go` files now import `testutil` directly
- **Extracted `applicableRuleIDs` helper** in `internal/tofuscan/output` — `computePassingRules` and `computePassedRulesCount` duplicated the same matching-rules loop (~25 lines each)
- **Collapsed `PrintWarningSummary`/`PrintErrorSummary`** into a shared `printSummaryCards` helper with `warningLines`/`errorLines` extractors — the two functions had identical card-render structure

Net: −45 lines, all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scan result calculations so passed-rule counts accurately reflect only rules applicable to the detected resource types.
  - Refreshed warning and error summaries with consistent grouping, badges/titles, file listings, and extracted message lines.

- **Refactor**
  - Streamlined how the CLI checks for OpenTofu availability across formatting, testing, and validation commands.
  - Consolidated shared summary-rendering logic to reduce duplication.

- **Chores**
  - Updated the Go workflow’s Regal lint action to a newer pinned version.

- **Tests**
  - Removed an obsolete internal test covering a now-removed command execution helper.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->